### PR TITLE
Update README with 0.0.6 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ jobs:
         run: |
           docker build -t docker.io/my-organization/my-app:${{ github.sha }} .
       - name: Run vulnerability scanner
-        uses: aquasecurity/trivy-action@0.0.5
+        uses: aquasecurity/trivy-action@0.0.6
         with:
           image-ref: 'docker.io/my-organization/my-app:${{ github.sha }}'
           format: 'table'


### PR DESCRIPTION
Closes #7 

Actions using `0.0.5` are failing with 
`(Line: 26, Col: 10): Unrecognized named-value: 'inputs'. Located at position 1 within expression: inputs.version`