### PR TITLE
Feature: Add support for `--ignore-unfixed`

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,12 @@ jobs:
         run: |
           docker build -t docker.io/my-organization/my-app:${{ github.sha }} .
       - name: Run vulnerability scanner
-        uses: aquasecurity/trivy-action@0.0.6
+        uses: aquasecurity/trivy-action@0.0.7
         with:
           image-ref: 'docker.io/my-organization/my-app:${{ github.sha }}'
           format: 'table'
           exit-code: '1'
+          ignore-unfixed: true
           severity: 'CRITICAL,HIGH'
 ```
 
@@ -55,12 +56,13 @@ jobs:
 
 Following inputs can be used as `step.with` keys:
 
-| Name        | Type   | Default                            | Description                                   |
-|-------------|--------|------------------------------------|-----------------------------------------------|
-| `image-ref` | String |                                    | Image reference, e.g. `alpine:3.10.2`         |
-| `format`    | String | `table`                            | Output format (`table`, `json`)               |
-| `exit-code` | String | `0`                                | Exit code when vulnerabilities were found     |
-| `severity`  | String | `UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL` | Severities of vulnerabilities to be displayed |
+| Name             | Type    | Default                            | Description                                   |
+|------------------|---------|------------------------------------|-----------------------------------------------|
+| `image-ref`      | String  |                                    | Image reference, e.g. `alpine:3.10.2`         |
+| `format`         | String  | `table`                            | Output format (`table`, `json`)               |
+| `exit-code`      | String  | `0`                                | Exit code when vulnerabilities were found     |
+| `ignore-unfixed` | Boolean | false                              | Ignore unpatched/unfixed vulnerabilities      |
+| `severity`       | String  | `UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL` | Severities of vulnerabilities to be displayed |
 
 [release]: https://github.com/aquasecurity/trivy-action/releases/latest
 [release-img]: https://img.shields.io/github/release/aquasecurity/trivy-action.svg?logo=github

--- a/action.yaml
+++ b/action.yaml
@@ -9,6 +9,10 @@ inputs:
     description: 'exit code when vulnerabilities were found'
     required: false
     default: '0'
+  ignore-unfixed:
+    description: 'ignore unfixed vulnerabilities'
+    required: false
+    default: false
   severity:
     description: 'severities of vulnerabilities to be displayed'
     required: false
@@ -24,5 +28,6 @@ runs:
     - 'image'
     - '--format=${{ inputs.format }}'
     - '--exit-code=${{ inputs.exit-code }}'
+    - '--ignore-unfixed=${{ inputs.ignore-unfixed }}'
     - '--severity=${{ inputs.severity }}'
     - '${{ inputs.image-ref }}'


### PR DESCRIPTION
Closes #9

This PR adds support for `--ignore-unfixed` run argument.

I took the liberty and updated the README.me to point to tag `0.0.7`.

### Test

```yml
- name: Run scanner with --ignore-fixed=false
  uses: zoispag/trivy-action@master
  if: always()
  with:
    image-ref: 'image'
    exit-code: '1'
    severity: 'MEDIUM'
    ignore-unfixed: false

- name: Run scanner with --ignore-fixed not set
  uses: zoispag/trivy-action@master
  if: always()
  with:
    image-ref: 'image'
    exit-code: '1'
    severity: 'MEDIUM'

- name: Run scanner with --ignore-fixed=true
  uses: zoispag/trivy-action@master
  if: always()
  with:
    image-ref: 'image'
    exit-code: '1'
    severity: 'MEDIUM'
    ignore-unfixed: true
```

![image](https://user-images.githubusercontent.com/21138205/85305681-b22f2f00-b4ad-11ea-857e-1a3904470957.png)

- **Run scanner with --ignore-fixed=false** executes: `docker.io/aquasec/trivy:latest  "image" "--format=table" "--ignore-unfixed=false" "--exit-code=1" "--severity=MEDIUM" "image"`
- **Run scanner with --ignore-fixed not set** executes: `docker.io/aquasec/trivy:latest  "image" "--format=table" "--ignore-unfixed=false" "--exit-code=1" "--severity=MEDIUM" "image"`
- **Run scanner with --ignore-fixed=true** executes: `docker.io/aquasec/trivy:latest  "image" "--format=table" "--ignore-unfixed=true" "--exit-code=1" "--severity=MEDIUM" "image"`