### PR TITLE
SARIF: Add support for sarif output

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Following inputs can be used as `step.with` keys:
 | Name             | Type    | Default                            | Description                                   |
 |------------------|---------|------------------------------------|-----------------------------------------------|
 | `image-ref`      | String  |                                    | Image reference, e.g. `alpine:3.10.2`         |
-| `format`         | String  | `table`                            | Output format (`table`, `json`)               |
+| `format`         | String  | `table`                            | Output format (`table`, `json`, `sarif`)      |
 | `exit-code`      | String  | `0`                                | Exit code when vulnerabilities were found     |
 | `ignore-unfixed` | Boolean | false                              | Ignore unpatched/unfixed vulnerabilities      |
 | `severity`       | String  | `UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL` | Severities of vulnerabilities to be displayed |

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Following inputs can be used as `step.with` keys:
 | Name             | Type    | Default                            | Description                                   |
 |------------------|---------|------------------------------------|-----------------------------------------------|
 | `image-ref`      | String  |                                    | Image reference, e.g. `alpine:3.10.2`         |
-| `format`         | String  | `table`                            | Output format (`table`, `json`, `sarif`)      |
+| `format`         | String  | `table`                            | Output format (`table`, `json`, `template`)   |
 | `exit-code`      | String  | `0`                                | Exit code when vulnerabilities were found     |
 | `ignore-unfixed` | Boolean | false                              | Ignore unpatched/unfixed vulnerabilities      |
 | `severity`       | String  | `UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL` | Severities of vulnerabilities to be displayed |

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Following inputs can be used as `step.with` keys:
 |------------------|---------|------------------------------------|-----------------------------------------------|
 | `image-ref`      | String  |                                    | Image reference, e.g. `alpine:3.10.2`         |
 | `format`         | String  | `table`                            | Output format (`table`, `json`, `template`)   |
+| `template`       | String  |                                    | Output template (`@contrib/sarif.tpl`, `@contrib/gitlab.tpl`, `@contrib/junit.tpl`)|
 | `exit-code`      | String  | `0`                                | Exit code when vulnerabilities were found     |
 | `ignore-unfixed` | Boolean | false                              | Ignore unpatched/unfixed vulnerabilities      |
 | `severity`       | String  | `UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL` | Severities of vulnerabilities to be displayed |

--- a/README.md
+++ b/README.md
@@ -50,6 +50,42 @@ jobs:
           severity: 'CRITICAL,HIGH'
 ```
 
+### Using Trivy with GitHub Code Scanning
+If you have [GitHub code scanning](https://docs.github.com/en/github/finding-security-vulnerabilities-and-errors-in-your-code/about-code-scanning) available you can use Trivy as a scanning tool as follows:
+```yaml
+name: build
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Setup Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.14
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Build an image from Dockerfile
+        run: |
+          docker build -t docker.io/my-organization/my-app:${{ github.sha }} .
+      - name: Run vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: 'docker.io/my-organization/my-app:${{ github.sha }}'
+          format: 'template'
+          template: '@contrib/sarif.tpl'
+          output: 'trivy-results.sarif'
+      - name: Upload Trivy scan results to Security tab
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: 'trivy-results.sarif'
+```
+
 ## Customizing
 
 ### inputs
@@ -61,6 +97,7 @@ Following inputs can be used as `step.with` keys:
 | `image-ref`      | String  |                                    | Image reference, e.g. `alpine:3.10.2`         |
 | `format`         | String  | `table`                            | Output format (`table`, `json`, `template`)   |
 | `template`       | String  |                                    | Output template (`@contrib/sarif.tpl`, `@contrib/gitlab.tpl`, `@contrib/junit.tpl`)|
+| `output`         | String  |                                    | Save results to a file                        |
 | `exit-code`      | String  | `0`                                | Exit code when vulnerabilities were found     |
 | `ignore-unfixed` | Boolean | false                              | Ignore unpatched/unfixed vulnerabilities      |
 | `severity`       | String  | `UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL` | Severities of vulnerabilities to be displayed |

--- a/action.yaml
+++ b/action.yaml
@@ -21,16 +21,21 @@ inputs:
     description: 'output format (table, json, template)'
     required: false
     default: 'table'
-  output:
-    description: 'write results to an output file'
+  template:
+    description: 'use an existing template for rendering output (@contrib/sarif.tpl, @contrib/gitlab.tpl, @contrib/junit.tpl'
     required: false
-    default: 'scan.results'
+    default: ''
+  output:
+    description: 'writes results to a file with the specified file name'
+    required: false
+    default: ''
 runs:
   using: 'docker'
   image: 'docker://docker.io/aquasec/trivy:latest'
   args:
     - 'image'
     - '--format=${{ inputs.format }}'
+    - '--template=${{ inputs.template }}'
     - '--exit-code=${{ inputs.exit-code }}'
     - '--ignore-unfixed=${{ inputs.ignore-unfixed }}'
     - '--severity=${{ inputs.severity }}'

--- a/action.yaml
+++ b/action.yaml
@@ -18,9 +18,13 @@ inputs:
     required: false
     default: 'UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL'
   format:
-    description: 'output format (table, json)'
+    description: 'output format (table, json, sarif)'
     required: false
     default: 'table'
+  output:
+    description: 'write results to an output file'
+    required: false
+    default: 'scan.results'
 runs:
   using: 'docker'
   image: 'docker://docker.io/aquasec/trivy:latest'
@@ -30,4 +34,5 @@ runs:
     - '--exit-code=${{ inputs.exit-code }}'
     - '--ignore-unfixed=${{ inputs.ignore-unfixed }}'
     - '--severity=${{ inputs.severity }}'
+    - '--output=${{ inputs.output }}'
     - '${{ inputs.image-ref }}'

--- a/action.yaml
+++ b/action.yaml
@@ -18,7 +18,7 @@ inputs:
     required: false
     default: 'UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL'
   format:
-    description: 'output format (table, json, sarif)'
+    description: 'output format (table, json, template)'
     required: false
     default: 'table'
   output:


### PR DESCRIPTION
Adds the ability to output and save to a SARIF format file.

Requires: https://github.com/aquasecurity/trivy/pull/571 to be merged.

Signed-off-by: Simarpreet Singh <simar@linux.com>