### PR TITLE
action: Use a mounted dir

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -39,5 +39,5 @@ runs:
     - '--exit-code=${{ inputs.exit-code }}'
     - '--ignore-unfixed=${{ inputs.ignore-unfixed }}'
     - '--severity=${{ inputs.severity }}'
-    - '--output=${{ inputs.output }}'
+    - '--output=${{ github.workspace }}/${{ inputs.output }}'
     - '${{ inputs.image-ref }}'


### PR DESCRIPTION
Since now Trivy no longer runs as root user we need to mount dirs and write only to the ones it does have access to.
<img width="1277" alt="image" src="https://user-images.githubusercontent.com/1254783/88936936-54260200-d238-11ea-8eca-e8b78eb262c7.png">

See more: https://github.com/aquasecurity/trivy/issues/519

Environment variables: https://docs.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables#default-environment-variables

Signed-off-by: Simarpreet Singh <simar@linux.com>