### PR TITLE
Add a link to the Trivy repository to the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Trivy Action
 
-> [GitHub Action](https://github.com/features/actions) for Trivy
+> [GitHub Action](https://github.com/features/actions) for [Trivy](https://github.com/aquasecurity/trivy)
 
 [![GitHub Release][release-img]][release]
 [![GitHub Marketplace][marketplace-img]][marketplace]


### PR DESCRIPTION
I found this Action via the [Github blog post announcing the integration](https://github.blog/2020-10-07-announcing-third-party-code-scanning-tools-infrastructure-as-code-and-container-scanning/#trivvy-by-aqua-security) and had to take a detour via the Docker image listed in `action.yaml` to find the source and more on Trivy, so I think it'd be nice to have a direct link in the Readme. :smiley_cat: 