### PR TITLE
Pass --cache-dir as global argument to Trivy

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -58,6 +58,11 @@ if [ $input ]; then
 fi
 ignoreUnfixed=$(echo $ignoreUnfixed | tr -d '\r')
 
+GLOBAL_ARGS=""
+if [ $cacheDir ];then
+  GLOBAL_ARGS="$GLOBAL_ARGS --cache-dir $cacheDir"
+fi
+
 ARGS=""
 if [ $format ];then
  ARGS="$ARGS --format $format"
@@ -86,12 +91,9 @@ if [ $skipDirs ];then
     ARGS="$ARGS --skip-dirs $i"
   done
 fi
-if [ $cacheDir ];then
-  ARGS="$ARGS --cache-dir $cacheDir"
-fi
 if [ $timeout ];then
   ARGS="$ARGS --timeout $timeout"
 fi
 
 echo "Running trivy with options: " --no-progress "${ARGS}" "${artifactRef}"
-trivy ${scanType} --no-progress $ARGS ${artifactRef}
+trivy $GLOBAL_ARGS ${scanType} --no-progress $ARGS ${artifactRef}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -96,4 +96,5 @@ if [ $timeout ];then
 fi
 
 echo "Running trivy with options: " --no-progress "${ARGS}" "${artifactRef}"
+echo "Global options: " "${GLOBAL_ARGS}"
 trivy $GLOBAL_ARGS ${scanType} --no-progress $ARGS ${artifactRef}


### PR DESCRIPTION
Fixes #50 

As per Trivy usage (https://aquasecurity.github.io/trivy/v0.18.3/usage/) --cache-dir is a global options and should be passed before the command.
With that change I'm able to run the Trivy action with the `cache-dir` input defined and without getting any error.

I've mirrored the `$ARGS` logic as `$GLOBAL_ARGS` in case support for other global options is required in the future. However, so far I've left `$GLOBAL_ARGS` out of the info statement: `Running trivy with options: ...` as I wasn't sure if this is needed for global options and if it is how best to include it; suggestions welcome.