### PR TITLE
Update docker base image for Trivy to enable use of config as scan-type

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM aquasec/trivy:0.18.1
+FROM aquasec/trivy:0.19.1
 COPY entrypoint.sh /
 RUN apk --no-cache add bash
 RUN chmod +x /entrypoint.sh

--- a/action.yaml
+++ b/action.yaml
@@ -1,4 +1,4 @@
-name: 'Aqua Security Trivy'
+name: 'Aqua Security Trivy with config'
 description: 'Scans container images for vulnerabilities with Trivy'
 author: 'Aqua Security'
 inputs:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -101,6 +101,6 @@ if [ $ignorePolicy ];then
   ARGS="$ARGS --ignore-policy $ignorePolicy"
 fi
 
-echo "Running trivy with options: " --no-progress "${ARGS}" "${artifactRef}"
+echo "Running trivy with options: ${ARGS}" "${artifactRef}"
 echo "Global options: " "${GLOBAL_ARGS}"
-trivy $GLOBAL_ARGS ${scanType} --no-progress $ARGS ${artifactRef}
+trivy $GLOBAL_ARGS ${scanType} $ARGS ${artifactRef}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -76,10 +76,10 @@ fi
 if [ $exitCode ];then
  ARGS="$ARGS --exit-code $exitCode"
 fi
-if [ "$ignoreUnfixed" == "true" && "$vulnType" != "config"];then
+if [ "$ignoreUnfixed" == "true" ] && ["$vulnType" != "config"];then
   ARGS="$ARGS --ignore-unfixed"
 fi
-if [ $vulnType && "$vulnType" != "config"];then
+if [ $vulnType ] && ["$vulnType" != "config"];then
   ARGS="$ARGS --vuln-type $vulnType"
 fi
 if [ $severity ];then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -76,10 +76,10 @@ fi
 if [ $exitCode ];then
  ARGS="$ARGS --exit-code $exitCode"
 fi
-if [ "$ignoreUnfixed" == "true" ];then
+if [ "$ignoreUnfixed" == "true" && "$vulnType" != "config"];then
   ARGS="$ARGS --ignore-unfixed"
 fi
-if [ $vulnType ];then
+if [ $vulnType && "$vulnType" != "config"];then
   ARGS="$ARGS --vuln-type $vulnType"
 fi
 if [ $severity ];then


### PR DESCRIPTION
This PR should resolve https://github.com/aquasecurity/trivy-action/issues/54
![image](https://user-images.githubusercontent.com/18095238/125729453-3b5d7637-416a-4f17-96e7-e4f24214ea92.png)

