### PR TITLE
Enable config scanning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM aquasec/trivy:0.18.1
+FROM aquasec/trivy:0.19.1
 COPY entrypoint.sh /
 RUN apk --no-cache add bash
 RUN chmod +x /entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -123,6 +123,41 @@ jobs:
           sarif_file: 'trivy-results.sarif'
 ```
 
+### Using Trivy to scan Infrastucture as Code
+It's also possible to scan your IAC/YAML repos with Trivy's built-in repo scan. This can be handy if you want to run Trivy as a build time check on each PR that gets opened in your repo. This helps you identify potential vulnerablites that might get introduced with each PR.
+
+If you have [GitHub code scanning](https://docs.github.com/en/github/finding-security-vulnerabilities-and-errors-in-your-code/about-code-scanning) available you can use Trivy as a scanning tool as follows:
+```yaml
+name: build
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Run Trivy vulnerability scanner in repo mode
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: 'config'
+          hide-progress: false
+          format: 'table'
+          exit-code: '1'
+          ignore-unfixed: true
+          severity: 'CRITICAL,HIGH'
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: 'trivy-results.sarif'
+```
+
 ### Using Trivy to scan your private registry
 It's also possible to scan your private registry with Trivy's built-in image scan. All you have to do is set ENV vars.
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ jobs:
 ```
 
 ### Using Trivy to scan Infrastucture as Code
-It's also possible to scan your IAC/YAML repos with Trivy's built-in repo scan. This can be handy if you want to run Trivy as a build time check on each PR that gets opened in your repo. This helps you identify potential vulnerablites that might get introduced with each PR.
+It's also possible to scan your IaC repos with Trivy's built-in repo scan. This can be handy if you want to run Trivy as a build time check on each PR that gets opened in your repo. This helps you identify potential vulnerablites that might get introduced with each PR.
 
 If you have [GitHub code scanning](https://docs.github.com/en/github/finding-security-vulnerabilities-and-errors-in-your-code/about-code-scanning) available you can use Trivy as a scanning tool as follows:
 ```yaml

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Run Trivy vulnerability scanner in repo mode
+      - name: Run Trivy vulnerability scanner in IaC mode
         uses: aquasecurity/trivy-action@master
         with:
           scan-type: 'config'

--- a/action.yaml
+++ b/action.yaml
@@ -61,6 +61,10 @@ inputs:
     description: 'filter vulnerabilities with OPA rego language'
     required: false
     default: ''
+  hide-progress:
+    description: 'hide progress output'
+    required: false
+    default: 'true'
 runs:
   using: 'docker'
   image: "Dockerfile"
@@ -80,3 +84,4 @@ runs:
     - '-m ${{ inputs.cache-dir }}'
     - '-n ${{ inputs.timeout }}'
     - '-o ${{ inputs.ignore-policy }}'
+    - '-p ${{ inputs.hide-progress }}'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -79,10 +79,10 @@ fi
 if [ $exitCode ];then
  ARGS="$ARGS --exit-code $exitCode"
 fi
-if [ "$ignoreUnfixed" == "true" ];then
+if [ "$ignoreUnfixed" == "true" ] && [ "$scanType" != "config" ];then
   ARGS="$ARGS --ignore-unfixed"
 fi
-if [ $vulnType ];then
+if [ $vulnType ] && [ "$scanType" != "config" ];then
   ARGS="$ARGS --vuln-type $vulnType"
 fi
 if [ $severity ];then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -55,7 +55,7 @@ done
 
 scanType=$(echo $scanType | tr -d '\r')
 export artifactRef="${imageRef}"
-if [ "${scanType}" = "fs" ];then
+if [ "${scanType}" = "fs" ] ||  [ "${scanType}" = "config" ];then
   artifactRef=$(echo $scanRef | tr -d '\r')
 fi
 input=$(echo $input | tr -d '\r')

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-while getopts "a:b:c:d:e:f:g:h:i:j:k:l:m:n:o:" o; do
+while getopts "a:b:c:d:e:f:g:h:i:j:k:l:m:n:o:p:" o; do
    case "${o}" in
        a)
          export scanType=${OPTARG}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -47,6 +47,9 @@ while getopts "a:b:c:d:e:f:g:h:i:j:k:l:m:n:o:" o; do
        o)
          export ignorePolicy=${OPTARG}
        ;;
+       p)
+         export hideProgress=${OPTARG}
+       ;;
   esac
 done
 
@@ -100,7 +103,10 @@ fi
 if [ $ignorePolicy ];then
   ARGS="$ARGS --ignore-policy $ignorePolicy"
 fi
+if [ "$hideProgress" == "true" ];then
+  ARGS="$ARGS --no-progress"
+fi
 
-echo "Running trivy with options: " --no-progress "${ARGS}" "${artifactRef}"
+echo "Running trivy with options: ${ARGS}" "${artifactRef}"
 echo "Global options: " "${GLOBAL_ARGS}"
-trivy $GLOBAL_ARGS ${scanType} --no-progress $ARGS ${artifactRef}
+trivy $GLOBAL_ARGS ${scanType} $ARGS ${artifactRef}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -63,6 +63,7 @@ if [ $input ]; then
   artifactRef="--input $input"
 fi
 ignoreUnfixed=$(echo $ignoreUnfixed | tr -d '\r')
+hideProgress=$(echo $hideProgress | tr -d '\r')
 
 GLOBAL_ARGS=""
 if [ $cacheDir ];then


### PR DESCRIPTION
This PR resolves https://github.com/aquasecurity/trivy-action/issues/54
and is a follow up to https://github.com/aquasecurity/trivy-action/pull/55

Example output running with the below action params:
scan-type: 'config'
hide-progress: false
format: 'table'
severity: 'UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL'

![image](https://user-images.githubusercontent.com/18095238/126425662-38385b0d-c6b8-40ab-ba40-c2f259058512.png)
