### PR TITLE
Bump base image version to 0.19.2 to fix issue with config scanning.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM aquasec/trivy:0.19.1
+FROM aquasec/trivy:0.19.2
 COPY entrypoint.sh /
 RUN apk --no-cache add bash
 RUN chmod +x /entrypoint.sh


### PR DESCRIPTION
Fix https://github.com/aquasecurity/trivy-action/issues/57
- Bumps the base trivy image to 0.19.2 to fix an issue where config scanning breaks.