### PR TITLE
chore: Update trivy version to 0.25

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM aquasec/trivy:0.23.0
+FROM aquasec/trivy:0.25.0
 COPY entrypoint.sh /
 RUN apk --no-cache add bash
 RUN chmod +x /entrypoint.sh


### PR DESCRIPTION
Updating the trivy version. I tested the main options -a image, -a config, -a rootfs. 