### PR TITLE
Update Trivy Version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM aquasec/trivy:0.27.1
+FROM aquasec/trivy:0.28.1
 COPY entrypoint.sh /
 RUN apk --no-cache add bash
 RUN chmod +x /entrypoint.sh


### PR DESCRIPTION
Update the Dockerfile to use the latest release of Trivy.

The version of Trivy used in the action currently has errors when generating table output for scans of some files. The latest version, 0.28.1 has fixed these errors.