### PR TITLE
Use AWS public ECR instead of rate-limiting dockerhub

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM aquasec/trivy:0.28.1
+FROM public.ecr.aws/aquasecurity/trivy:0.28.1
 COPY entrypoint.sh /
 RUN apk --no-cache add bash
 RUN chmod +x /entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/aquasecurity/trivy:0.28.1
+FROM ghcr.io/aquasecurity/trivy:0.28.1
 COPY entrypoint.sh /
 RUN apk --no-cache add bash
 RUN chmod +x /entrypoint.sh


### PR DESCRIPTION
Unfortunately, using the Trivy action repeatedly in the CI can cause them to fail because of DockerHub pull rate limiting.
One shall not get this issue by using the public AWS ECR.

[Here is a test run](https://github.com/tanguy-platsec/trivy-ecr-testing/runs/6725884119?check_suite_focus=true) on a private repository to prove the pull works properly of course.

Please let me know of the reason the action uses the image from DockerHub if there is one.