### PR TITLE
feat: update codeql-action/upload-sarif to v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ jobs:
           output: 'trivy-results.sarif'
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v1
+        uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: 'trivy-results.sarif'
 ```
@@ -115,7 +115,7 @@ jobs:
           output: 'trivy-results.sarif'
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v1
+        uses: github/codeql-action/upload-sarif@v2
         if: always()
         with:
           sarif_file: 'trivy-results.sarif'
@@ -152,7 +152,7 @@ jobs:
           severity: 'CRITICAL'
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v1
+        uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: 'trivy-results.sarif'
 ```
@@ -187,7 +187,7 @@ jobs:
           severity: 'CRITICAL'
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v1
+        uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: 'trivy-results.sarif'
 ```
@@ -222,7 +222,7 @@ jobs:
           severity: 'CRITICAL,HIGH'
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v1
+        uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: 'trivy-results.sarif'
 ```
@@ -259,7 +259,7 @@ jobs:
           TRIVY_PASSWORD: Password
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v1
+        uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: 'trivy-results.sarif'
 ```
@@ -296,7 +296,7 @@ jobs:
           AWS_DEFAULT_REGION: us-west-2
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v1
+        uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: 'trivy-results.sarif'
 ```
@@ -330,7 +330,7 @@ jobs:
           GOOGLE_APPLICATION_CREDENTIAL: /path/to/credential.json
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v1
+        uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: 'trivy-results.sarif'
 ```
@@ -364,7 +364,7 @@ jobs:
           TRIVY_PASSWORD: Password
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v1
+        uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: 'trivy-results.sarif'
 ```

--- a/workflow.yml
+++ b/workflow.yml
@@ -29,6 +29,6 @@ jobs:
           severity: 'CRITICAL,HIGH'
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v1
+        uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
Hi :wave: 

Description :
- This PR updates the `github/codeql-action/upload-sarif` action from `v1` to `v2`.

Reason:
- The `v1` of this action is deprecated and there is a warning annotation each time you run it:
```
CodeQL Action v1 will be deprecated on December 7th, 2022. Please upgrade to v2. For more information, 
see https://github.blog/changelog/2022-04-27-code-scanning-deprecation-of-codeql-action-v1/
```

David

Signed-off-by: David <davidcalvertfr@gmail.com>