### PR TITLE
docs: added missing HTML template and removed deprecated SARIF template

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,7 +382,7 @@ Following inputs can be used as `step.with` keys:
 | `image-ref`      | String  |                                    | Image reference, e.g. `alpine:3.10.2`         |
 | `scan-ref`       | String  | `/github/workspace/`               | Scan reference, e.g. `/github/workspace/` or `.`|
 | `format`         | String  | `table`                            | Output format (`table`, `json`, `sarif`)   |
-| `template`       | String  |                                    | Output template (`@/contrib/gitlab.tpl`, `@/contrib/junit.tpl`)|
+| `template`       | String  |                                    | Output template (`@/contrib/gitlab.tpl`, `@/contrib/junit.tpl`, `@/contrib/html.tpl`)|
 | `output`         | String  |                                    | Save results to a file                        |
 | `exit-code`      | String  | `0`                                | Exit code when specified vulnerabilities are found     |
 | `ignore-unfixed` | Boolean | false                              | Ignore unpatched/unfixed vulnerabilities      |

--- a/action.yaml
+++ b/action.yaml
@@ -38,7 +38,7 @@ inputs:
     required: false
     default: 'table'
   template:
-    description: 'use an existing template for rendering output (@/contrib/sarif.tpl, @/contrib/gitlab.tpl, @/contrib/junit.tpl, @/contrib/html.tpl)'
+    description: 'use an existing template for rendering output (@/contrib/gitlab.tpl, @/contrib/junit.tpl, @/contrib/html.tpl)'
     required: false
     default: ''
   output:

--- a/action.yaml
+++ b/action.yaml
@@ -38,7 +38,7 @@ inputs:
     required: false
     default: 'table'
   template:
-    description: 'use an existing template for rendering output (@/contrib/sarif.tpl, @/contrib/gitlab.tpl, @/contrib/junit.tpl'
+    description: 'use an existing template for rendering output (@/contrib/sarif.tpl, @/contrib/gitlab.tpl, @/contrib/junit.tpl, @/contrib/html.tpl)'
     required: false
     default: ''
   output:


### PR DESCRIPTION
I simply added the missing HTML template in the README.md and action.yaml files, and removed the deprecated SARIF template (https://github.com/aquasecurity/trivy/discussions/1571) from the action.yaml file.