### PR TITLE
Add support for --dependency-tree option 

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,6 +459,7 @@ Following inputs can be used as `step.with` keys:
 | `security-checks` | String  | `vuln,secret`                      | comma-separated list of what security issues to detect (`vuln`,`secret`,`config`)               |
 | `trivyignores`    | String  |                                    | comma-separated list of relative paths in repository to one or more `.trivyignore` files        |
 | `github-pat`      | String  |                                    | GitHub Personal Access Token (PAT) for sending SBOM scan results to GitHub Dependency Snapshots |
+| `dependency-tree` | String  | `false`                            | show dependency origin tree                                                                     |
 
 [release]: https://github.com/aquasecurity/trivy-action/releases/latest
 [release-img]: https://img.shields.io/github/release/aquasecurity/trivy-action.svg?logo=github

--- a/action.yaml
+++ b/action.yaml
@@ -85,6 +85,10 @@ inputs:
   github-pat:
     description: 'GitHub Personal Access Token (PAT) for submitting SBOM to GitHub Dependency Snapshot API'
     required: false
+  dependency-tree:
+    description: 'show dependency origin tree'
+    required: false
+    default: 'false'
 
 runs:
   using: 'docker'
@@ -111,3 +115,4 @@ runs:
     - '-s ${{ inputs.security-checks }}'
     - '-t ${{ inputs.trivyignores }}'
     - '-u ${{ inputs.github-pat }}'
+    - '-v ${{ inputs.dependency-tree }}'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-while getopts "a:b:c:d:e:f:g:h:i:j:k:l:m:n:o:p:q:r:s:t:u:" o; do
+while getopts "a:b:c:d:e:f:g:h:i:j:k:l:m:n:o:p:q:r:s:t:u:v:" o; do
    case "${o}" in
        a)
          export scanType=${OPTARG}
@@ -65,6 +65,9 @@ while getopts "a:b:c:d:e:f:g:h:i:j:k:l:m:n:o:p:q:r:s:t:u:" o; do
        u)
          export githubPAT=${OPTARG}
        ;;
+       v)
+         export dependencyTree=${OPTARG}
+       ;;
   esac
 done
 
@@ -79,6 +82,7 @@ if [ $input ]; then
 fi
 ignoreUnfixed=$(echo $ignoreUnfixed | tr -d '\r')
 hideProgress=$(echo $hideProgress | tr -d '\r')
+
 
 GLOBAL_ARGS=""
 if [ $cacheDir ];then
@@ -156,6 +160,12 @@ if [ "$skipFiles" ];then
     ARGS="$ARGS --skip-files $i"
   done
 fi
+
+dependencyTree=$(echo $dependencyTree | tr -d '\r')
+if [ "$dependencyTree" == "true" ] && [ "$scanType" != "config" ];then
+  ARGS="$ARGS --dependency-tree"
+fi
+
 
 echo "Running trivy with options: ${ARGS}" "${artifactRef}"
 echo "Global options: " "${GLOBAL_ARGS}"


### PR DESCRIPTION
This PR adds support for supplying --dependency-tree option to the action.

See https://github.com/aquasecurity/trivy-action/issues/140 for the feature request.