### PR TITLE
docs: add trivy-config to table

### DIFF
--- a/README.md
+++ b/README.md
@@ -500,6 +500,7 @@ Following inputs can be used as `step.with` keys:
 | `list-all-pkgs`   | String  |                                    | Output all packages regardless of vulnerability                                                 |
 | `security-checks` | String  | `vuln,secret`                      | comma-separated list of what security issues to detect (`vuln`,`secret`,`config`)               |
 | `trivyignores`    | String  |                                    | comma-separated list of relative paths in repository to one or more `.trivyignore` files        |
+| `trivy-config`    | String  |                                    | Path to trivy.yaml config                                                                       |
 | `github-pat`      | String  |                                    | GitHub Personal Access Token (PAT) for sending SBOM scan results to GitHub Dependency Snapshots |
 
 [release]: https://github.com/aquasecurity/trivy-action/releases/latest


### PR DESCRIPTION
I was searching for an option to add --full-license and found out that you can add trivy.yaml. I realised this was missing from the table in the README, which was for me the first place I searched for this functionaltiy.