### PR TITLE
fix deprecated security-checks arg

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -115,8 +115,8 @@ if [ $vulnType ] && [ "$scanType" != "config" ] && [ "$scanType" != "sbom" ];the
   SARIF_ARGS="$SARIF_ARGS --vuln-type $vulnType"
 fi
 if [ $securityChecks ];then
-  ARGS="$ARGS --security-checks $securityChecks"
-  SARIF_ARGS="$SARIF_ARGS --security-checks $securityChecks"
+  ARGS="$ARGS --scanners $securityChecks"
+  SARIF_ARGS="$SARIF_ARGS --scanners $securityChecks"
 fi
 if [ $severity ];then
   ARGS="$ARGS --severity $severity"


### PR DESCRIPTION
Fixing this deprecation warning
```
2023-02-03T20:06:13.849Z	WARN	'--security-checks' is deprecated. Use '--scanners' instead.
```
replaced: --security-checks with --scanners