### PR TITLE
Change github-pat input name

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ jobs:
           format: 'github'
           output: 'dependency-results.sbom.json'
           image-ref: '.'
-          github-pat: '<github_pat_token>'
+          github-token: '<github_pat_token>'
 ```
 
 ### Using Trivy to scan your private registry

--- a/README.md
+++ b/README.md
@@ -501,7 +501,7 @@ Following inputs can be used as `step.with` keys:
 | `security-checks` | String  | `vuln,secret`                      | comma-separated list of what security issues to detect (`vuln`,`secret`,`config`)               |
 | `trivyignores`    | String  |                                    | comma-separated list of relative paths in repository to one or more `.trivyignore` files        |
 | `trivy-config`    | String  |                                    | Path to trivy.yaml config                                                                       |
-| `github-pat`      | String  |                                    | GitHub Personal Access Token (PAT) for sending SBOM scan results to GitHub Dependency Snapshots |
+| `github-token`      | String  |                                    | GitHub Personal Access Token (PAT) for sending SBOM scan results to GitHub Dependency Snapshots |
 | `limit-severities-for-sarif`      | Boolean  | false                                   | By default *SARIF* format enforces output of all vulnerabilities regardless of configured severities. To override this behavior set this parameter to **true** |
 
 [release]: https://github.com/aquasecurity/trivy-action/releases/latest

--- a/README.md
+++ b/README.md
@@ -501,7 +501,7 @@ Following inputs can be used as `step.with` keys:
 | `security-checks` | String  | `vuln,secret`                      | comma-separated list of what security issues to detect (`vuln`,`secret`,`config`)               |
 | `trivyignores`    | String  |                                    | comma-separated list of relative paths in repository to one or more `.trivyignore` files        |
 | `trivy-config`    | String  |                                    | Path to trivy.yaml config                                                                       |
-| `github-token`      | String  |                                    | GitHub Personal Access Token (PAT) for sending SBOM scan results to GitHub Dependency Snapshots |
+| `github-token`      | String  |                                    | Authentication token to enable sending SBOM scan results to GitHub Dependency Graph. Can be either a GitHub Personal Access Token (PAT) or GITHUB_TOKEN |
 | `limit-severities-for-sarif`      | Boolean  | false                                   | By default *SARIF* format enforces output of all vulnerabilities regardless of configured severities. To override this behavior set this parameter to **true** |
 
 [release]: https://github.com/aquasecurity/trivy-action/releases/latest

--- a/action.yaml
+++ b/action.yaml
@@ -82,8 +82,8 @@ inputs:
   artifact-type:
     description: 'input artifact type (image, fs, repo, archive) for SBOM generation'
     required: false
-  github-pat:
-    description: 'GitHub Personal Access Token (PAT) for submitting SBOM to GitHub Dependency Snapshot API'
+  github-token:
+    description: 'Authentication token to enable sending SBOM scan results to GitHub Dependency Graph. Can be either a GitHub Personal Access Token (PAT) or GITHUB_TOKEN'
     required: false
   trivy-config:
     description: 'path to trivy.yaml config'
@@ -116,6 +116,6 @@ runs:
     - '-r ${{ inputs.list-all-pkgs }}'
     - '-s ${{ inputs.security-checks }}'
     - '-t ${{ inputs.trivyignores }}'
-    - '-u ${{ inputs.github-pat }}'
+    - '-u ${{ inputs.github-token }}'
     - '-v ${{ inputs.trivy-config }}'
     - '-z ${{ inputs.limit-severities-for-sarif }}'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -191,7 +191,7 @@ if [[ "${format}" == "github" ]]; then
     printf "\n Uploading GitHub Dependency Snapshot"
     curl -H 'Accept: application/vnd.github+json' -H "Authorization: token $githubPAT" 'https://api.github.com/repos/'$GITHUB_REPOSITORY'/dependency-graph/snapshots' -d @./$(echo $output | xargs)
   else
-    printf "\n Failing GitHub Dependency Snapshot. Missing github-pat"
+    printf "\n Failing GitHub Dependency Snapshot. Missing github-token"
   fi
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -63,7 +63,7 @@ while getopts "a:b:c:d:e:f:g:h:i:j:k:l:m:n:o:p:q:r:s:t:u:v:z:" o; do
          export trivyIgnores=${OPTARG}
        ;;
        u)
-         export githubPAT=${OPTARG}
+         export githubToken=${OPTARG}
        ;;
        v)
          export trivyConfig=${OPTARG}
@@ -187,9 +187,9 @@ else
 fi
 
 if [[ "${format}" == "github" ]]; then
-  if [[ "$(echo $githubPAT | xargs)" != "" ]]; then
+  if [[ "$(echo $githubToken | xargs)" != "" ]]; then
     printf "\n Uploading GitHub Dependency Snapshot"
-    curl -H 'Accept: application/vnd.github+json' -H "Authorization: token $githubPAT" 'https://api.github.com/repos/'$GITHUB_REPOSITORY'/dependency-graph/snapshots' -d @./$(echo $output | xargs)
+    curl -H 'Accept: application/vnd.github+json' -H "Authorization: token $githubToken" 'https://api.github.com/repos/'$GITHUB_REPOSITORY'/dependency-graph/snapshots' -d @./$(echo $output | xargs)
   else
     printf "\n Failing GitHub Dependency Snapshot. Missing github-token"
   fi

--- a/test/data/repo.test
+++ b/test/data/repo.test
@@ -23,7 +23,7 @@
           "RuleID": "github-token",
           "Category": "GitHub",
           "Severity": "CRITICAL",
-          "Title": "GitHub Token (PAT or install acess token)",
+          "Title": "GitHub Token (PAT or install access token)",
           "StartLine": 5,
           "EndLine": 5,
           "Code": {

--- a/test/data/repo.test
+++ b/test/data/repo.test
@@ -49,11 +49,11 @@
               },
               {
                 "Number": 5,
-                "Content": "export GITHUB_PAT=****************************************",
+                "Content": "export GITHUB_TOKEN=****************************************",
                 "IsCause": true,
                 "Annotation": "",
                 "Truncated": false,
-                "Highlighted": "export GITHUB_PAT=****************************************",
+                "Highlighted": "export GITHUB_TOKEN=****************************************",
                 "FirstCause": true,
                 "LastCause": true
               },
@@ -68,7 +68,7 @@
               }
             ]
           },
-          "Match": "export GITHUB_PAT=****************************************",
+          "Match": "export GITHUB_TOKEN=****************************************",
           "Layer": {}
         }
       ]

--- a/test/data/repo.test
+++ b/test/data/repo.test
@@ -20,10 +20,10 @@
       "Class": "secret",
       "Secrets": [
         {
-          "RuleID": "github-pat",
+          "RuleID": "github-token",
           "Category": "GitHub",
           "Severity": "CRITICAL",
-          "Title": "GitHub Personal Access Token",
+          "Title": "GitHub Token (PAT or install acess token)",
           "StartLine": 5,
           "EndLine": 5,
           "Code": {


### PR DESCRIPTION
### What this PR does

Renames the `github-pat` input argument to `github-token`, as to better reflect the different kinds of tokens this input accepts, according to the changes made in #208.