### PR TITLE
Rename security-checks to scanners

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,31 +478,31 @@ jobs:
 
 Following inputs can be used as `step.with` keys:
 
-| Name              | Type    | Default                            | Description                                                                                     |
-|-------------------|---------|------------------------------------|-------------------------------------------------------------------------------------------------|
-| `scan-type`       | String  | `image`                            | Scan type, e.g. `image` or `fs`                                                                 |
-| `input`           | String  |                                    | Tar reference, e.g. `alpine-latest.tar`                                                         |
-| `image-ref`       | String  |                                    | Image reference, e.g. `alpine:3.10.2`                                                           |
-| `scan-ref`        | String  | `/github/workspace/`               | Scan reference, e.g. `/github/workspace/` or `.`                                                |
-| `format`          | String  | `table`                            | Output format (`table`, `json`, `sarif`, `github`)                                              |
-| `template`        | String  |                                    | Output template (`@/contrib/gitlab.tpl`, `@/contrib/junit.tpl`)                                 |
-| `output`          | String  |                                    | Save results to a file                                                                          |
-| `exit-code`       | String  | `0`                                | Exit code when specified vulnerabilities are found                                              |
-| `ignore-unfixed`  | Boolean | false                              | Ignore unpatched/unfixed vulnerabilities                                                        |
-| `vuln-type`       | String  | `os,library`                       | Vulnerability types (os,library)                                                                |
-| `severity`        | String  | `UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL` | Severities of vulnerabilities to scanned for and displayed                                      |
-| `skip-dirs`       | String  |                                    | Comma separated list of directories where traversal is skipped                                  |
-| `skip-files`      | String  |                                    | Comma separated list of files where traversal is skipped                                        |
-| `cache-dir`       | String  |                                    | Cache directory                                                                                 |
-| `timeout`         | String  | `5m0s`                             | Scan timeout duration                                                                           |
-| `ignore-policy`   | String  |                                    | Filter vulnerabilities with OPA rego language                                                   |
-| `hide-progress`   | String  | `true`                             | Suppress progress bar                                                                           |
-| `list-all-pkgs`   | String  |                                    | Output all packages regardless of vulnerability                                                 |
-| `security-checks` | String  | `vuln,secret`                      | comma-separated list of what security issues to detect (`vuln`,`secret`,`config`)               |
-| `trivyignores`    | String  |                                    | comma-separated list of relative paths in repository to one or more `.trivyignore` files        |
-| `trivy-config`    | String  |                                    | Path to trivy.yaml config                                                                       |
-| `github-pat`      | String  |                                    | GitHub Personal Access Token (PAT) for sending SBOM scan results to GitHub Dependency Snapshots |
-| `limit-severities-for-sarif`      | Boolean  | false                                   | By default *SARIF* format enforces output of all vulnerabilities regardless of configured severities. To override this behavior set this parameter to **true** |
+| Name                         | Type    | Default                            | Description                                                                                     |
+|------------------------------|---------|------------------------------------|-------------------------------------------------------------------------------------------------|
+| `scan-type`                  | String  | `image`                            | Scan type, e.g. `image` or `fs`                                                                 |
+| `input`                      | String  |                                    | Tar reference, e.g. `alpine-latest.tar`                                                         |
+| `image-ref`                  | String  |                                    | Image reference, e.g. `alpine:3.10.2`                                                           |
+| `scan-ref`                   | String  | `/github/workspace/`               | Scan reference, e.g. `/github/workspace/` or `.`                                                |
+| `format`                     | String  | `table`                            | Output format (`table`, `json`, `sarif`, `github`)                                              |
+| `template`                   | String  |                                    | Output template (`@/contrib/gitlab.tpl`, `@/contrib/junit.tpl`)                                 |
+| `output`                     | String  |                                    | Save results to a file                                                                          |
+| `exit-code`                  | String  | `0`                                | Exit code when specified vulnerabilities are found                                              |
+| `ignore-unfixed`             | Boolean | false                              | Ignore unpatched/unfixed vulnerabilities                                                        |
+| `vuln-type`                  | String  | `os,library`                       | Vulnerability types (os,library)                                                                |
+| `severity`                   | String  | `UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL` | Severities of vulnerabilities to scanned for and displayed                                      |
+| `skip-dirs`                  | String  |                                    | Comma separated list of directories where traversal is skipped                                  |
+| `skip-files`                 | String  |                                    | Comma separated list of files where traversal is skipped                                        |
+| `cache-dir`                  | String  |                                    | Cache directory                                                                                 |
+| `timeout`                    | String  | `5m0s`                             | Scan timeout duration                                                                           |
+| `ignore-policy`              | String  |                                    | Filter vulnerabilities with OPA rego language                                                   |
+| `hide-progress`              | String  | `true`                             | Suppress progress bar                                                                           |
+| `list-all-pkgs`              | String  |                                    | Output all packages regardless of vulnerability                                                 |
+| `runners`                    | String  | `vuln,secret`                      | comma-separated list of what security issues to detect (`vuln`,`secret`,`config`)               |
+| `trivyignores`               | String  |                                    | comma-separated list of relative paths in repository to one or more `.trivyignore` files        |
+| `trivy-config`               | String  |                                    | Path to trivy.yaml config                                                                       |
+| `github-pat`                 | String  |                                    | GitHub Personal Access Token (PAT) for sending SBOM scan results to GitHub Dependency Snapshots |
+| `limit-severities-for-sarif` | Boolean  | false                                   | By default *SARIF* format enforces output of all vulnerabilities regardless of configured severities. To override this behavior set this parameter to **true** |
 
 [release]: https://github.com/aquasecurity/trivy-action/releases/latest
 [release-img]: https://img.shields.io/github/release/aquasecurity/trivy-action.svg?logo=github

--- a/README.md
+++ b/README.md
@@ -498,7 +498,7 @@ Following inputs can be used as `step.with` keys:
 | `ignore-policy`              | String  |                                    | Filter vulnerabilities with OPA rego language                                                   |
 | `hide-progress`              | String  | `true`                             | Suppress progress bar                                                                           |
 | `list-all-pkgs`              | String  |                                    | Output all packages regardless of vulnerability                                                 |
-| `runners`                    | String  | `vuln,secret`                      | comma-separated list of what security issues to detect (`vuln`,`secret`,`config`)               |
+| `scanners`                   | String  | `vuln,secret`                      | comma-separated list of what security issues to detect (`vuln`,`secret`,`config`)               |
 | `trivyignores`               | String  |                                    | comma-separated list of relative paths in repository to one or more `.trivyignore` files        |
 | `trivy-config`               | String  |                                    | Path to trivy.yaml config                                                                       |
 | `github-pat`                 | String  |                                    | GitHub Personal Access Token (PAT) for sending SBOM scan results to GitHub Dependency Snapshots |

--- a/action.yaml
+++ b/action.yaml
@@ -71,7 +71,7 @@ inputs:
     description: 'output all packages regardless of vulnerability'
     required: false
     default: 'false'
-  security-checks:
+  scanners:
     description: 'comma-separated list of what security issues to detect'
     required: false
     default: ''
@@ -114,7 +114,7 @@ runs:
     - '-p ${{ inputs.hide-progress }}'
     - '-q ${{ inputs.skip-files }}'
     - '-r ${{ inputs.list-all-pkgs }}'
-    - '-s ${{ inputs.security-checks }}'
+    - '-s ${{ inputs.scanners }}'
     - '-t ${{ inputs.trivyignores }}'
     - '-u ${{ inputs.github-pat }}'
     - '-v ${{ inputs.trivy-config }}'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -57,7 +57,7 @@ while getopts "a:b:c:d:e:f:g:h:i:j:k:l:m:n:o:p:q:r:s:t:u:v:z:" o; do
          export listAllPkgs=${OPTARG}
        ;;
        s)
-         export runners=${OPTARG}
+         export scanners=${OPTARG}
        ;;
        t)
          export trivyIgnores=${OPTARG}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -57,7 +57,7 @@ while getopts "a:b:c:d:e:f:g:h:i:j:k:l:m:n:o:p:q:r:s:t:u:v:z:" o; do
          export listAllPkgs=${OPTARG}
        ;;
        s)
-         export securityChecks=${OPTARG}
+         export runners=${OPTARG}
        ;;
        t)
          export trivyIgnores=${OPTARG}
@@ -114,9 +114,9 @@ if [ $vulnType ] && [ "$scanType" != "config" ] && [ "$scanType" != "sbom" ];the
   ARGS="$ARGS --vuln-type $vulnType"
   SARIF_ARGS="$SARIF_ARGS --vuln-type $vulnType"
 fi
-if [ $securityChecks ];then
-  ARGS="$ARGS --security-checks $securityChecks"
-  SARIF_ARGS="$SARIF_ARGS --security-checks $securityChecks"
+if [ $scanners ];then
+  ARGS="$ARGS --scanners $scanners"
+  SARIF_ARGS="$SARIF_ARGS --scanners $scanners"
 fi
 if [ $severity ];then
   ARGS="$ARGS --severity $severity"

--- a/test/test.bats
+++ b/test/test.bats
@@ -4,7 +4,7 @@ bats_load_library bats-assert
 bats_load_library bats-file
 
 @test "trivy repo with securityCheck secret only" {
-  # trivy repo --format json --output repo.test --security-checks=secret https://github.com/krol3/demo-trivy/
+  # trivy repo --format json --output repo.test --scanners=secret https://github.com/krol3/demo-trivy/
   run ./entrypoint.sh '-b json' '-h repo.test' '-s secret' '-a repo' '-j https://github.com/krol3/demo-trivy/'
   run diff repo.test ./test/data/repo.test
   echo "$output"
@@ -52,7 +52,7 @@ bats_load_library bats-file
 }
 
 @test "trivy fs with securityChecks option" {
-  # trivy fs --format json --security-checks=vuln,config --output fs-scheck.test .
+  # trivy fs --format json --scanners=vuln,config --output fs-scheck.test .
   run ./entrypoint.sh '-a fs' '-b json' '-j .' '-s vuln,config,secret' '-h fs-scheck.test'
   run diff fs-scheck.test ./test/data/fs-scheck.test
   echo "$output"


### PR DESCRIPTION
Fixes https://github.com/aquasecurity/trivy-action/issues/210 

```
WARN	'--security-checks' is deprecated. Use '--scanners' instead.
```
