### PR TITLE
feat: add exit-code parameter to sarif format

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -105,6 +105,7 @@ if [ $template ] ;then
 fi
 if [ $exitCode ];then
  ARGS="$ARGS --exit-code $exitCode"
+ SARIF_ARGS="$SARIF_ARGS --exit-code $exitCode"
 fi
 if [ "$ignoreUnfixed" == "true" ] && [ "$scanType" != "config" ];then
   ARGS="$ARGS --ignore-unfixed"


### PR DESCRIPTION
Add exit-code parameter to sarif format execution.

Prior to version v0.9.0, Sarif format execution with `--exit-code` parameter was failing if any vulnerability found, this is because Trivy was run twice (sarif and silent + normal execution). As of > v0.9.0 exit-code does not work anymore.

We find it valuable in case you want to chain or perform different actions if the scanning fails.