### PR TITLE
chore: Make image-ref optional

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -8,7 +8,8 @@ inputs:
     default: 'image'
   image-ref:
     description: 'image reference(for backward compatibility)'
-    required: true
+    required: false
+    default: ''
   input:
     description: 'reference of tar file to scan'
     required: false


### PR DESCRIPTION
The image-ref input is required, but looks unnecessary with `scan-type: 'fs'`.
VSCode Editor reports problems, so I want to set it to `required: false`.

![スクリーンショット 2023-04-08 12 40 40](https://user-images.githubusercontent.com/117768/230701881-8e9cb0e1-f8c5-4c18-90b0-4f4eb7c9b716.png)
