### PR TITLE
Include args when using trivy config file

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -177,7 +177,7 @@ if [ "${format}" == "sarif" ] && [ "${limitSeveritiesForSARIF}" != "true" ]; the
   trivy --quiet ${scanType} --format sarif --output ${output} $SARIF_ARGS ${artifactRef}
 elif [ $trivyConfig ]; then
    echo "Running Trivy with trivy.yaml config from: " $trivyConfig
-   trivy --config $trivyConfig ${scanType} ${artifactRef}
+   trivy --config $trivyConfig ${ARGS} ${scanType} ${artifactRef}
    returnCode=$?
 else
    echo "Running trivy with options: trivy ${scanType} ${ARGS}" "${artifactRef}"

--- a/test/data/trivy-reduced.yaml
+++ b/test/data/trivy-reduced.yaml
@@ -1,0 +1,3 @@
+vulnerability:
+  type: os
+output: yamlconfig.test

--- a/test/test.bats
+++ b/test/test.bats
@@ -81,3 +81,11 @@ bats_load_library bats-file
   echo "$output"
   assert_files_equal yamlconfig.test ./test/data/yamlconfig.test
 }
+
+@test "trivy image with trivy.yaml config and args" {
+  # trivy --config=./test/data/trivy-reduced.yaml image alpine:3.10
+  run ./entrypoint.sh "-v ./test/data/trivy-reduced.yaml" "-a image" "-i alpine:3.10" "-b json" "-g CRITICAL"
+  run diff yamlconfig.test ./test/data/yamlconfig.test
+  echo "$output"
+  assert_files_equal yamlconfig.test ./test/data/yamlconfig.test
+}


### PR DESCRIPTION
This builds on an existing pull request by [leongyh](https://github.com/leongyh): https://github.com/aquasecurity/trivy-action/pull/207

Previously, arguments provided using regular flags were ignored if a trivy config file was provided

Note that this pull request makes no effort to deduce or merge desired argument if the same configuration with different values are provided both within the config file and as flags. Behaviour for this case would develop on the implementation of trivy.