### PR TITLE
Enhance GitHub Dependency Snapshot upload

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -169,6 +169,8 @@ if [ "$skipFiles" ];then
 fi
 
 trivyConfig=$(echo $trivyConfig | tr -d '\r')
+# To make sure that uploda GitHub Dependency Snapshot succeeds, disable the script that fails first.
+set +e
 if [ "${format}" == "sarif" ] && [ "${limitSeveritiesForSARIF}" != "true" ]; then
   # SARIF is special. We output all vulnerabilities,
   # regardless of severity level specified in this report.
@@ -186,6 +188,7 @@ else
    returnCode=$?
 fi
 
+set -e
 if [[ "${format}" == "github" ]]; then
   if [[ "$(echo $githubPAT | xargs)" != "" ]]; then
     printf "\n Uploading GitHub Dependency Snapshot"


### PR DESCRIPTION
Changes:

Disable script fails when run trivy scan.

Test:

Work at expect.
<img width="853" alt="image" src="https://github.com/aquasecurity/trivy-action/assets/2601077/f787a8e4-b436-4d4a-91ae-4409870ecc97">

