### PR TITLE
fix: set return code after each Trivy call

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -181,13 +181,12 @@ if [ "${format}" == "sarif" ] && [ "${limitSeveritiesForSARIF}" != "true" ]; the
 elif [ $trivyConfig ]; then
    echo "Running Trivy with trivy.yaml config from: " $trivyConfig
    trivy --config $trivyConfig ${scanType} ${artifactRef}
-   returnCode=$?
 else
    echo "Running trivy with options: trivy ${scanType} ${ARGS}" "${artifactRef}"
    echo "Global options: " "${GLOBAL_ARGS}"
    trivy $GLOBAL_ARGS ${scanType} ${ARGS} ${artifactRef}
-   returnCode=$?
 fi
+returnCode=$?
 
 set -e
 if [[ "${format}" == "github" ]]; then


### PR DESCRIPTION
This change moves the return code to outside the trivy call. This fixes #228 as the return code was not being propagated.