### PR TITLE
fix: mark image-ref attribute optional

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -8,7 +8,7 @@ inputs:
     default: 'image'
   image-ref:
     description: 'image reference(for backward compatibility)'
-    required: true
+    required: false
   input:
     description: 'reference of tar file to scan'
     required: false


### PR DESCRIPTION
Attribute `image-ref` of action is marked as required. But we don't set it and it works. So it is not actually required.

Would be nice to fix this minor things, because Github Actions extension/linter complains about it.

Fixing https://github.com/aquasecurity/trivy-action/issues/260