### PR TITLE
feature: add filesystem alias

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -77,7 +77,7 @@ done
 
 scanType=$(echo $scanType | tr -d '\r')
 export artifactRef="${imageRef}"
-if [ "${scanType}" = "repo" ] || [ "${scanType}" = "fs" ] ||  [ "${scanType}" = "config" ] ||  [ "${scanType}" = "rootfs" ];then
+if [ "${scanType}" = "repo" ] || [ "${scanType}" = "fs" ] || [ "${scanType}" = "filesystem" ] ||  [ "${scanType}" = "config" ] ||  [ "${scanType}" = "rootfs" ];then
   artifactRef=$(echo $scanRef | tr -d '\r')
 fi
 input=$(echo $input | tr -d '\r')


### PR DESCRIPTION
* Adds filesystem to scan-type.
* resolves: [scan-ref doesn't work when using filesystem instead of fs](https://github.com/aquasecurity/trivy-action/issues/264)