### PR TITLE
Update Dockerfile to 0.46.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/aquasecurity/trivy:0.46.0
+FROM ghcr.io/aquasecurity/trivy:0.46.1
 COPY entrypoint.sh /
 RUN apk --no-cache add bash curl npm
 RUN chmod +x /entrypoint.sh


### PR DESCRIPTION
This update fixes https://github.com/aquasecurity/trivy/issues/5441