### PR TITLE
fix: Fix `skip-files` and `hide-progress` options not being applied when using Sarif report format

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -163,6 +163,7 @@ if [ $ignorePolicy ];then
 fi
 if [ "$hideProgress" == "true" ];then
   ARGS="$ARGS --no-progress"
+  SARIF_ARGS="$SARIF_ARGS --no-progress"
 fi
 
 listAllPkgs=$(echo $listAllPkgs | tr -d '\r')
@@ -173,6 +174,7 @@ if [ "$skipFiles" ];then
   for i in $(echo $skipFiles | tr "," "\n")
   do
     ARGS="$ARGS --skip-files $i"
+    SARIF_ARGS="$SARIF_ARGS --skip-files $i"
   done
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -ex
+set -e
 while getopts "a:b:c:d:e:f:g:h:i:j:k:l:m:n:o:p:q:r:s:t:u:v:x:z:" o; do
    case "${o}" in
        a)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -ex
 while getopts "a:b:c:d:e:f:g:h:i:j:k:l:m:n:o:p:q:r:s:t:u:v:x:z:" o; do
    case "${o}" in
        a)


### PR DESCRIPTION
Added the possibility to use `skip-files` and `hide-progress` options when using Sarif as report format.