### PR TITLE
fix: Fix 'tf-var' arg not passing when using 'sarif' format

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -e
+
 while getopts "a:b:c:d:e:f:g:h:i:j:k:l:m:n:o:p:q:r:s:t:u:v:x:z:" o; do
    case "${o}" in
        a)
@@ -137,6 +138,7 @@ if [ $skipDirs ];then
 fi
 if [ $tfVars ] && [ "$scanType" == "config" ];then
   ARGS="$ARGS --tf-vars $tfVars"
+  SARIF_ARGS="$SARIF_ARGS --tf-vars $tfVars"
 fi 
 
 if [ $trivyIgnores ];then
@@ -186,7 +188,7 @@ if [ "${format}" == "sarif" ] && [ "${limitSeveritiesForSARIF}" != "true" ]; the
   # regardless of severity level specified in this report.
   # This is a feature, not a bug :)
   echo "Building SARIF report with options: ${SARIF_ARGS}" "${artifactRef}"
-  trivy --quiet ${scanType} --format sarif --output ${output} $SARIF_ARGS ${artifactRef}
+  trivy ${scanType} --format sarif --output ${output} $SARIF_ARGS ${artifactRef}
 elif [ $trivyConfig ]; then
    echo "Running Trivy with trivy.yaml config from: " $trivyConfig
    trivy --config $trivyConfig ${scanType} ${artifactRef}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -188,6 +188,7 @@ if [ "${format}" == "sarif" ] && [ "${limitSeveritiesForSARIF}" != "true" ]; the
   # regardless of severity level specified in this report.
   # This is a feature, not a bug :)
   echo "Building SARIF report with options: ${SARIF_ARGS}" "${artifactRef}"
+  echo "Ignore all severity level being defined since limit-severities-for-sarif: false"
   trivy ${scanType} --format sarif --output ${output} $SARIF_ARGS ${artifactRef}
 elif [ $trivyConfig ]; then
    echo "Running Trivy with trivy.yaml config from: " $trivyConfig


### PR DESCRIPTION
fix #310 

When using `sarif` format and `tf-var` args together
```
ᐅ docker run -it trivy-action \
"-a config" \
"-b sarif" \
"-c " \
"-d 1" \
"-e false" \
"-f os,library" \
"-g CRITICAL,HIGH" \
"-h trivy-results.sarif" \
"-i " \
"-j ." \
"-k " \
"-l " \
"-m " \
"-n " \
"-o " \
"-p false" \
"-q " \
"-r false" \
"-s " \
"-t " \
"-u " \
"-v " \
"-x ./terraform/terraform.tfvars.json" \
"-z "
```

tf-var arg will not pass, and since it is `--quiet` people don't know what happen and scan will not kick in
```
+ echo 'Building SARIF report with options:  --exit-code  1' .
Building SARIF report with options:  --exit-code  1 .
+ trivy --quiet config --format sarif --output trivy-results.sarif --exit-code 1 .
```

after this fix 
```
Building SARIF report with options:  --exit-code  1 --tf-vars  ./terraform/terraform.tfvars.json .
Ignore all severity level being defined since limit-severities-for-sarif: false
2024-02-17T19:53:09.430Z        INFO    Misconfiguration scanning is enabled
2024-02-17T19:53:09.430Z        INFO    Need to update the built-in policies
2024-02-17T19:53:09.430Z        INFO    Downloading the built-in policies...
45.79 KiB / 45.79 KiB [-------------------------------------------------------------------------------------------------] 100.00% ? p/s 100ms
2024-02-17T19:53:10.621Z        INFO    Detected config files: 0
```