### PR TITLE
fix: Refer to scan-ref when scan-type is "sbom"

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -80,7 +80,7 @@ done
 
 scanType=$(echo $scanType | tr -d '\r')
 export artifactRef="${imageRef}"
-if [ "${scanType}" = "repo" ] || [ "${scanType}" = "fs" ] || [ "${scanType}" = "filesystem" ] ||  [ "${scanType}" = "config" ] ||  [ "${scanType}" = "rootfs" ];then
+if [ "${scanType}" = "repo" ] || [ "${scanType}" = "fs" ] || [ "${scanType}" = "filesystem" ] ||  [ "${scanType}" = "config" ] ||  [ "${scanType}" = "rootfs" ] || [ "${scanType}" = "sbom" ];then
   artifactRef=$(echo $scanRef | tr -d '\r')
 fi
 input=$(echo $input | tr -d '\r')


### PR DESCRIPTION
Fix: #173

When `scan-type` is "sbom", the key to specify the target SBOM file should be `scan-ref`, not `image-ref`. This pull request makes a minor modification to ensure that when `scan-type` is "sbom", `scanRef` is specified for `artifactRef` within `entrypoint.sh`.
