### PR TITLE
Make 'hide-progress' input working again

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ jobs:
       run: |
         docker pull <your-docker-image>
         docker save -o vuln-image.tar <your-docker-image>
-        
+
     - name: Run Trivy vulnerability scanner in tarball mode
       uses: aquasecurity/trivy-action@master
       with:
@@ -287,7 +287,7 @@ jobs:
         uses: aquasecurity/trivy-action@master
         with:
           scan-type: 'config'
-          hide-progress: false
+          hide-progress: true
           format: 'sarif'
           output: 'trivy-results.sarif'
           exit-code: '1'
@@ -303,7 +303,7 @@ jobs:
 ### Using Trivy to generate SBOM
 It's possible for Trivy to generate an [SBOM](https://www.aquasec.com/cloud-native-academy/supply-chain-security/sbom/) of your dependencies and submit them to a consumer like [GitHub Dependency Graph](https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-the-dependency-graph).
 
-The [sending of an SBOM to GitHub](https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/using-the-dependency-submission-api) feature is only available if you currently have GitHub Dependency Graph [enabled in your repo](https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/configuring-the-dependency-graph#enabling-and-disabling-the-dependency-graph-for-a-private-repository). 
+The [sending of an SBOM to GitHub](https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/using-the-dependency-submission-api) feature is only available if you currently have GitHub Dependency Graph [enabled in your repo](https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/configuring-the-dependency-graph#enabling-and-disabling-the-dependency-graph-for-a-private-repository).
 
 In order to send results to GitHub Dependency Graph, you will need to create a [GitHub PAT](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) or use the [GitHub installation access token](https://docs.github.com/en/actions/security-guides/automatic-token-authentication) (also known as `GITHUB_TOKEN`):
 
@@ -554,7 +554,7 @@ Following inputs can be used as `step.with` keys:
 | `cache-dir`                  | String  |                                    | Cache directory                                                                                                                                                |
 | `timeout`                    | String  | `5m0s`                             | Scan timeout duration                                                                                                                                          |
 | `ignore-policy`              | String  |                                    | Filter vulnerabilities with OPA rego language                                                                                                                  |
-| `hide-progress`              | String  | `true`                             | Suppress progress bar                                                                                                                                          |
+| `hide-progress`              | String  | `false`                            | Suppress progress bar and log output                                                                                                                           |
 | `list-all-pkgs`              | String  |                                    | Output all packages regardless of vulnerability                                                                                                                |
 | `scanners`                   | String  | `vuln,secret`                      | comma-separated list of what security issues to detect (`vuln`,`secret`,`config`)                                                                              |
 | `trivyignores`               | String  |                                    | comma-separated list of relative paths in repository to one or more `.trivyignore` files                                                                       |

--- a/action.yaml
+++ b/action.yaml
@@ -65,8 +65,9 @@ inputs:
     required: false
     default: ''
   hide-progress:
-    description: 'hide progress output'
+    description: 'suppress progress bar and log output'
     required: false
+    default: 'true'
   list-all-pkgs:
     description: 'output all packages regardless of vulnerability'
     required: false
@@ -123,4 +124,3 @@ runs:
     - '-v ${{ inputs.trivy-config }}'
     - '-x ${{ inputs.tf-vars }}'
     - '-z ${{ inputs.limit-severities-for-sarif }}'
-    

--- a/action.yaml
+++ b/action.yaml
@@ -67,7 +67,6 @@ inputs:
   hide-progress:
     description: 'suppress progress bar and log output'
     required: false
-    default: 'true'
   list-all-pkgs:
     description: 'output all packages regardless of vulnerability'
     required: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -137,7 +137,7 @@ if [ $skipDirs ];then
 fi
 if [ $tfVars ] && [ "$scanType" == "config" ];then
   ARGS="$ARGS --tf-vars $tfVars"
-fi 
+fi
 
 if [ $trivyIgnores ];then
   for f in $(echo $trivyIgnores | tr "," "\n")
@@ -162,8 +162,8 @@ if [ $ignorePolicy ];then
   SARIF_ARGS="$SARIF_ARGS --ignore-policy $ignorePolicy"
 fi
 if [ "$hideProgress" == "true" ];then
-  ARGS="$ARGS --no-progress"
-  SARIF_ARGS="$SARIF_ARGS --no-progress"
+  ARGS="$ARGS --quiet"
+  SARIF_ARGS="$SARIF_ARGS --quiet"
 fi
 
 listAllPkgs=$(echo $listAllPkgs | tr -d '\r')


### PR DESCRIPTION
I tried to use [this](https://github.com/aquasecurity/trivy-action?tab=readme-ov-file#using-trivy-to-scan-infrastructure-as-code) example, but Trivy is returning an error, when defining `hide-progress: false` or `hide-progress: true` input.
![image](https://github.com/aquasecurity/trivy-action/assets/15939365/809ecb67-9219-4f69-a26a-23ae54bad814)

This PR allows Trivy to use the correct `--quiet` flag, instead of non existing `--no-progress`.
![image](https://github.com/aquasecurity/trivy-action/assets/15939365/849cd759-a6be-4d5b-b386-541ba780a284)


