### PR TITLE
Allow for replacing FROM image in locked down environments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/aquasecurity/trivy:0.50.1
+FROM placeholder
 COPY entrypoint.sh /
 RUN apk --no-cache add bash curl npm
 RUN chmod +x /entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -591,6 +591,7 @@ Following inputs can be used as `step.with` keys:
 | `github-pat`                 | String  |                                    | Authentication token to enable sending SBOM scan results to GitHub Dependency Graph. Can be either a GitHub Personal Access Token (PAT) or GITHUB_TOKEN        |
 | `limit-severities-for-sarif` | Boolean | false                              | By default *SARIF* format enforces output of all vulnerabilities regardless of configured severities. To override this behavior set this parameter to **true** |
 | `docker-host`                | String  |                                    | By default it is set to `unix://var/run/docker.sock`, but can be updated to help with containerized infrastructure values                                      |
+| `base-image`                 | String   | `ghcr.io/aquasecurity/trivy:0.50.1` | Change the path, hostname or image name of the image running the scans. |
 
 ### Environment variables
 You can use [Trivy environment variables][trivy-env] to set the necessary options (including flags that are not supported by [Inputs](#inputs), such as `--secret-config`).

--- a/action.yaml
+++ b/action.yaml
@@ -97,10 +97,17 @@ inputs:
   docker-host:
     description: 'unix domain socket path to use for docker scanning, ex. unix:///var/run/docker.sock'
     required: false
+  base-image:
+    description: 'alternative base-image URL'
+    default: 'ghcr.io/aquasecurity/trivy:0.50.1'
+    required: false
 
 runs:
   using: 'docker'
   image: "Dockerfile"
+  pre-entrypoint: 'setup.sh'
+  env:
+    base_image: '${{ inputs.base-image }}'
   args:
     - '-a ${{ inputs.scan-type }}'
     - '-b ${{ inputs.format }}'

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,10 @@
+#!/bin/env bash
+set -o nounset
+set -o errexit
+set -o errtrace
+set -o pipefail
+IFS=$'\n\t'
+
+[ ! -z "${base_image}" ] && true || false
+
+sed 's/placeholder/'"${base_image}"'/' Dockerfile


### PR DESCRIPTION
See #333 for background

The purpose is to do a simple replacement of the word `placeholder` in the `Dockerfile`. I have read-through the documentation for the [github actions.yaml](https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runs-for-docker-container-actions) but it seems that there is no easy way to add a `--build-args`. 

The logic is then to run a preparatory shell script to alter the Dockerfile (can most likely be done in a more fashionable manner) and this is here done via sed.