### PR TITLE
Set severity when output is sarif

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,16 +265,20 @@ jobs:
 ```
 
 ### Using Trivy to scan Infrastructure as Code
-It's also possible to scan your IaC repos with Trivy's built-in repo scan. This can be handy if you want to run Trivy as a build time check on each PR that gets opened in your repo. This helps you identify potential vulnerablites that might get introduced with each PR.
+It's also possible to scan your IaC repos with Trivy's built-in repo scan. This can be handy if you want to run Trivy as a build time check on each PR that gets opened in your repo. This helps you identify potential vulnerabilities that might get introduced with each PR.
 
 If you have [GitHub code scanning](https://docs.github.com/en/github/finding-security-vulnerabilities-and-errors-in-your-code/about-code-scanning) available you can use Trivy as a scanning tool as follows:
 ```yaml
-name: build
+name: trivy-config-scan
 on:
   push:
     branches:
       - main
   pull_request:
+    branches:
+      -main
+  workflow_dispatch:
+  
 jobs:
   build:
     name: Build
@@ -284,16 +288,17 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Run Trivy vulnerability scanner in IaC mode
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@7b7aa264d83dc58691451798b4d117d53d21edfe
         with:
           scan-type: 'config'
           hide-progress: false
           format: 'sarif'
           output: 'trivy-results.sarif'
-          exit-code: '1'
+          exit-code: '0'
           ignore-unfixed: true
           severity: 'CRITICAL,HIGH'
-
+          vuln-type: config
+          
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v2
         with:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -127,6 +127,7 @@ if [ $scanners ];then
 fi
 if [ $severity ];then
   ARGS="$ARGS --severity $severity"
+  SARIF_ARGS="$SARIF_ARGS --severity $severity"
 fi
 if [ $output ];then
   ARGS="$ARGS --output $output"


### PR DESCRIPTION
Before this fix the `--severity` flag and values were not added to the sarif input. Hence, when a default value of 'CRITICAL,HIGH' was supplied, it would simply be ignored and report everything. The result is producing a bunch of noisy alerts, and anin't nobody got time for that!

Before the fix:
![sarif-no-severity-on-main](https://github.com/aquasecurity/trivy-action/assets/1355145/86b1ebbc-568d-415e-8bcd-8549a70140ed)

with this PR fix:
![austimkelly-severity-sarif-fix](https://github.com/aquasecurity/trivy-action/assets/1355145/053bf220-5c48-4e5b-9839-75c0269345cf)
