### PR TITLE
fix: 🐛 allow trivy-config and other options to be used together

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -195,7 +195,7 @@ if [ "${format}" == "sarif" ] && [ "${limitSeveritiesForSARIF}" != "true" ]; the
   trivy --quiet ${scanType} --format sarif --output ${output} $SARIF_ARGS ${artifactRef}
 elif [ $trivyConfig ]; then
    echo "Running Trivy with trivy.yaml config from: " $trivyConfig
-   trivy --config $trivyConfig ${scanType} ${artifactRef}
+   trivy --config $trivyConfig ${scanType} ${ARGS}" ${artifactRef}
 else
    echo "Running trivy with options: trivy ${scanType} ${ARGS}" "${artifactRef}"
    echo "Global options: " "${GLOBAL_ARGS}"


### PR DESCRIPTION
resolved: #337 

## Summary

Allow trivy-config and other options to be used together.
