### PR TITLE
Bump trivy version to v0.50.2

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,7 +1,7 @@
 name: "build"
 on: [push, pull_request]
 env:
-  TRIVY_VERSION: 0.50.1
+  TRIVY_VERSION: 0.50.2
   BATS_LIB_PATH: '/usr/lib/'
 jobs:
   build:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/aquasecurity/trivy:0.50.1
+FROM ghcr.io/aquasecurity/trivy:0.50.2
 COPY entrypoint.sh /
 RUN apk --no-cache add bash curl npm
 RUN chmod +x /entrypoint.sh


### PR DESCRIPTION
It was released 4 hours ago...

https://github.com/aquasecurity/trivy/releases/tag/v0.50.2