### PR TITLE
chore(deps): bump Trivy to v0.51.1

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,7 +1,7 @@
 name: "build"
 on: [push, pull_request]
 env:
-  TRIVY_VERSION: 0.50.2
+  TRIVY_VERSION: 0.51.1
   BATS_LIB_PATH: '/usr/lib/'
 jobs:
   build:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/aquasecurity/trivy:0.50.2
+FROM ghcr.io/aquasecurity/trivy:0.51.1
 COPY entrypoint.sh /
 RUN apk --no-cache add bash curl npm
 RUN chmod +x /entrypoint.sh


### PR DESCRIPTION
## Description
Bump Trivy to [v0.51.1](https://github.com/aquasecurity/trivy/releases/tag/v0.51.1)