### PR TITLE
[fix] Use environment variable for GitHub API

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -85,6 +85,10 @@ inputs:
   github-pat:
     description: 'GitHub Personal Access Token (PAT) for submitting SBOM to GitHub Dependency Snapshot API'
     required: false
+  github-api-url:
+    description: 'URL of the GitHub REST API for submitting SBOM to GitHub Dependency Snapshot API'
+    required: false
+    default: ${{ github.api_url }}
   trivy-config:
     description: 'path to trivy.yaml config'
     required: false
@@ -124,6 +128,7 @@ runs:
     - '-t ${{ inputs.trivyignores }}'
     - '-u ${{ inputs.github-pat }}'
     - '-v ${{ inputs.trivy-config }}'
+    - '-w ${{ inputs.github-api-url }}'
     - '-x ${{ inputs.tf-vars }}'
     - '-z ${{ inputs.limit-severities-for-sarif }}'
     - '-y ${{ inputs.docker-host }}'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-while getopts "a:b:c:d:e:f:g:h:i:j:k:l:m:n:o:p:q:r:s:t:u:v:x:y:z:" o; do
+while getopts "a:b:c:d:e:f:g:h:i:j:k:l:m:n:o:p:q:r:s:t:u:v:w:x:y:z:" o; do
    case "${o}" in
        a)
          export scanType=${OPTARG}
@@ -67,6 +67,9 @@ while getopts "a:b:c:d:e:f:g:h:i:j:k:l:m:n:o:p:q:r:s:t:u:v:x:y:z:" o; do
        ;;
        v)
          export trivyConfig=${OPTARG}
+       ;;
+       w)
+         export githubApiUrl=${OPTARG}
        ;;
        x)
          export tfVars=${OPTARG}
@@ -207,7 +210,7 @@ set -e
 if [[ "${format}" == "github" ]]; then
   if [[ "$(echo $githubPAT | xargs)" != "" ]]; then
     printf "\n Uploading GitHub Dependency Snapshot"
-    curl -H 'Accept: application/vnd.github+json' -H "Authorization: token $githubPAT" ''$GITHUB_API_URL'/repos/'$GITHUB_REPOSITORY'/dependency-graph/snapshots' -d @./$(echo $output | xargs)
+    curl -H 'Accept: application/vnd.github+json' -H "Authorization: token $githubPAT" ''$githubApiUrl'/repos/'$GITHUB_REPOSITORY'/dependency-graph/snapshots' -d @./$(echo $output | xargs)
   else
     printf "\n Failing GitHub Dependency Snapshot. Missing github-pat"
   fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -207,7 +207,7 @@ set -e
 if [[ "${format}" == "github" ]]; then
   if [[ "$(echo $githubPAT | xargs)" != "" ]]; then
     printf "\n Uploading GitHub Dependency Snapshot"
-    curl -H 'Accept: application/vnd.github+json' -H "Authorization: token $githubPAT" 'https://api.github.com/repos/'$GITHUB_REPOSITORY'/dependency-graph/snapshots' -d @./$(echo $output | xargs)
+    curl -H 'Accept: application/vnd.github+json' -H "Authorization: token $githubPAT" ''$GITHUB_API_URL'/repos/'$GITHUB_REPOSITORY'/dependency-graph/snapshots' -d @./$(echo $output | xargs)
   else
     printf "\n Failing GitHub Dependency Snapshot. Missing github-pat"
   fi


### PR DESCRIPTION
Use `GITHUB_API_URL` ([docs](https://docs.github.com/actions/learn-github-actions/variables#default-environment-variables)) for the request to the dependency snapshot endpoint so requests work in GitHub Enterprise Server where the API isn't found at `api.github.com`.

Resolves #312.
