### PR TITLE
Trivy allow alt db

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -100,6 +100,7 @@ inputs:
   db-repository:
     description: 'vulnerability DB repository address, ex. my-registry.example.com/mirrors/aquasecurity/trivy-db'
     required: false
+    default: ''
 
 runs:
   using: 'docker'

--- a/action.yaml
+++ b/action.yaml
@@ -97,6 +97,9 @@ inputs:
   docker-host:
     description: 'unix domain socket path to use for docker scanning, ex. unix:///var/run/docker.sock'
     required: false
+  db-repository:
+    description: 'vulnerability DB repository address, ex. my-registry.example.com/mirrors/aquasecurity/trivy-db'
+    required: false
 
 runs:
   using: 'docker'
@@ -125,5 +128,6 @@ runs:
     - '-u ${{ inputs.github-pat }}'
     - '-v ${{ inputs.trivy-config }}'
     - '-x ${{ inputs.tf-vars }}'
-    - '-z ${{ inputs.limit-severities-for-sarif }}'
     - '-y ${{ inputs.docker-host }}'
+    - '-z ${{ inputs.limit-severities-for-sarif }}'
+    - '-0 ${{ inputs.db-repository }}'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -187,7 +187,7 @@ if [ "$skipFiles" ];then
   done
 fi
 
-if [ "$dbRepository" ]; then
+if [ $dbRepository ]; then
   ARGS="$ARGS --db-repository $dbRepository"
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-while getopts "a:b:c:d:e:f:g:h:i:j:k:l:m:n:o:p:q:r:s:t:u:v:x:y:z:" o; do
+while getopts "a:b:c:d:e:f:g:h:i:j:k:l:m:n:o:p:q:r:s:t:u:v:x:y:z:0:" o; do
    case "${o}" in
        a)
          export scanType=${OPTARG}
@@ -76,6 +76,9 @@ while getopts "a:b:c:d:e:f:g:h:i:j:k:l:m:n:o:p:q:r:s:t:u:v:x:y:z:" o; do
        ;;
        z)
          export limitSeveritiesForSARIF=${OPTARG}
+       ;;
+       0)
+         export dbRepository=${OPTARG}
        ;;
   esac
 done
@@ -182,6 +185,10 @@ if [ "$skipFiles" ];then
     ARGS="$ARGS --skip-files $i"
     SARIF_ARGS="$SARIF_ARGS --skip-files $i"
   done
+fi
+
+if [ "$dbRepository" ]; then
+  ARGS="$ARGS --db-repository $dbRepository"
 fi
 
 trivyConfig=$(echo $trivyConfig | tr -d '\r')


### PR DESCRIPTION
This change allows users to select an alternative DB repo for the database.

I have tested this without the new input being specified, and also by using an ECR pull through repo pointing back at GHCR as the input for the alternative db repository. This will allow for a workaround in case of issues with GHCR/etc and also (if enough folks use this) reduce direct load on GHCR