### PR TITLE
ci: use `setup-trivy` to install Trivy

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -108,8 +108,10 @@ runs:
   using: 'composite'
   steps:
     - name: Install Trivy
-      shell: bash
-      run: curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sudo sh -s -- -b /usr/local/bin ${{ inputs.version }}
+      uses: aquasecurity/setup-trivy@v0.1.0
+      with:
+        version: ${{ inputs.version }}
+        cache: ${{ inputs.cache }}
 
     - name: Get current date
       id: date


### PR DESCRIPTION
## Description
For some runners there is a problem with `curl` and `sudo` when installing Trivy.
See #403 for details

So we need to use [setup-trivy](https://github.com/aquasecurity/setup-trivy/) to install Trivy.

Test runs:
- https://github.com/DmitriyLewen/test-trivy-action/actions/runs/11252839297
- https://github.com/DmitriyLewen/test-trivy-action/actions/runs/11252890226

## Related issues
- Close #403