### PR TITLE
Fix oras command not found in "Update Trivy Cache" action

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,9 @@ jobs:
   update-trivy-db:
     runs-on: ubuntu-latest
     steps:
+      - name: Setup oras
+        uses: oras-project/setup-oras@v1
+
       - name: Get current date
         id: date
         run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Since the latest ubuntu image has been updated to ubuntu 24.04 and "oras" command not found in the new image

reference: https://github.com/Tiryoh/docker-ros2-desktop-vnc/pull/186