### PR TITLE
feat: Allow skipping setup

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -103,11 +103,16 @@ inputs:
     description: 'Used to specify whether caching is needed. Set to false, if you would like to disable caching.'
     required: false
     default: 'true'
+  skip-setup-trivy:
+    description: 'skip calling the setup-trivy action to install trivy'
+    required: false
+    default: 'false'
 
 runs:
   using: 'composite'
   steps:
     - name: Install Trivy
+      if: ${{ inputs.skip-setup-trivy == 'false' }}
       uses: aquasecurity/setup-trivy@v0.1.0
       with:
         version: ${{ inputs.version }}


### PR DESCRIPTION
If a user is invoking the action multiple times then the trivy binary gets installed multiple times.  Users can avoid this by managing the installation themselves and setting the skip-setup input to true, or by letting the action install in on their first invocation and then setting skip-setup to true on subsequent invocations

This is an alternative solution to aquasecurity/setup-trivy#7 as discussed in that PR to address aquasecurity/setup-trivy#6

By allowing users to control whether the call to the `setup-trivy` action is made they can control how the `trivy` binary is installed, and avoid installing it multiple times if they have workflows that call `trivy` multiple times.

Added an example test at https://github.com/rvesse/setup-trivy-debugging/blob/main/.github/workflows/setup-trivy-indirect-fixed.yml with job output at https://github.com/rvesse/setup-trivy-debugging/actions/runs/11342576655/job/31543286568 where we can see that Trivy is no longer installed multiple times