### PR TITLE
fix: add an output containing a pass/fail result

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -107,6 +107,10 @@ inputs:
     description: 'skip calling the setup-trivy action to install trivy'
     required: false
     default: 'false'
+outputs:
+  result:
+    description: "Result of the Trivy scan according to the parameters supplied. One of 'pass', 'fail'"
+    value: ${{ steps.trivy.outputs.result }}
 
 runs:
   using: 'composite'
@@ -177,6 +181,7 @@ runs:
         set_env_var_if_provided "TRIVY_DOCKER_HOST" "${{ inputs.docker-host }}" ""
 
     - name: Run Trivy
+      id: trivy
       shell: bash
       run: entrypoint.sh
       env:


### PR DESCRIPTION
Closes #412 

This adds a little basic logic to provide an output that gives the real result of the scan (findings or not) in a simple pass/fail format.

It still honours the exit code requested via the exit-code input in terms of pass/fail of the trivy command whilst providing the ability to take conditional actions later in a workflow (upload sarif, prepare reports in other formats using convert, uploading to another system etc)

Example from a workflow in a private repo using this branch:

![image](https://github.com/user-attachments/assets/e03f36f9-8372-4bec-b3c7-930ec8a11910)

Debug step in my workflow

```yaml
- name: Check Output
        env:
          RESULT: ${{ steps.scan.outputs.result }}
        run: |
          echo "Trivy scan result output: $RESULT"
```

![image](https://github.com/user-attachments/assets/d4f09736-c646-4f1e-8391-c5abfcfa869e)
