### PR TITLE
feat: add token for `setup-trivy`

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,22 @@ jobs:
           skip-setup-trivy: true
 ```
 
+#### Use non-default token to install Trivy
+GitHub Enterprise Server (GHES) uses an invalid `github.token` for `https://github.com` server.
+Therefore, you can't install `Trivy` using the `setup-trivy` action.
+
+To fix this problem, you need to overwrite the token for `setup-trivy` using `token-setup-trivy` input:
+```yaml
+    - name: Run Trivy scanner without cache
+      uses: aquasecurity/trivy-action@0.28.0
+      with:
+        scan-type: 'fs'
+        scan-ref: '.'
+        token-setup-trivy: ${{ secrets.GITHUB_PAT }}
+```
+
+GitHub even has [create-github-app-token](https://github.com/actions/create-github-app-token) for similar cases.
+
 ### Scanning a Tarball
 ```yaml
 name: build
@@ -754,7 +770,7 @@ Following inputs can be used as `step.with` keys:
 | `input`                      | String  |                                    | Tar reference, e.g. `alpine-latest.tar`                                                                                                                        |
 | `image-ref`                  | String  |                                    | Image reference, e.g. `alpine:3.10.2`                                                                                                                          |
 | `scan-ref`                   | String  | `/github/workspace/`               | Scan reference, e.g. `/github/workspace/` or `.`                                                                                                               |
-| `format`                     | String  | `table`                            | Output format (`table`, `json`, `template`, `sarif`, `cyclonedx`, `spdx`, `spdx-json`, `github`, `cosign-vuln`)                                                                                                             |
+| `format`                     | String  | `table`                            | Output format (`table`, `json`, `template`, `sarif`, `cyclonedx`, `spdx`, `spdx-json`, `github`, `cosign-vuln`)                                                |
 | `template`                   | String  |                                    | Output template (`@/contrib/gitlab.tpl`, `@/contrib/junit.tpl`)                                                                                                |
 | `tf-vars`                    | String  |                                    | path to Terraform variables file                                                                                                                               |
 | `output`                     | String  |                                    | Save results to a file                                                                                                                                         |
@@ -769,7 +785,7 @@ Following inputs can be used as `step.with` keys:
 | `ignore-policy`              | String  |                                    | Filter vulnerabilities with OPA rego language                                                                                                                  |
 | `hide-progress`              | String  | `false`                            | Suppress progress bar and log output                                                                                                                           |
 | `list-all-pkgs`              | String  |                                    | Output all packages regardless of vulnerability                                                                                                                |
-| `scanners`                   | String  | `vuln,secret`                      | comma-separated list of what security issues to detect (`vuln`,`secret`,`misconfig`,`license`)                                                                              |
+| `scanners`                   | String  | `vuln,secret`                      | comma-separated list of what security issues to detect (`vuln`,`secret`,`misconfig`,`license`)                                                                 |
 | `trivyignores`               | String  |                                    | comma-separated list of relative paths in repository to one or more `.trivyignore` files                                                                       |
 | `trivy-config`               | String  |                                    | Path to trivy.yaml config                                                                                                                                      |
 | `github-pat`                 | String  |                                    | Authentication token to enable sending SBOM scan results to GitHub Dependency Graph. Can be either a GitHub Personal Access Token (PAT) or GITHUB_TOKEN        |
@@ -777,6 +793,7 @@ Following inputs can be used as `step.with` keys:
 | `docker-host`                | String  |                                    | By default it is set to `unix://var/run/docker.sock`, but can be updated to help with containerized infrastructure values                                      |
 | `version`                    | String  | `v0.56.1`                          | Trivy version to use, e.g. `latest` or `v0.56.1`                                                                                                               |
 | `skip-setup-trivy`           | Boolean | false                              | Skip calling the `setup-trivy` action to install `trivy`                                                                                                       |
+| `token-setup-trivy`          | Boolean |                                    | Overwrite `github.token` used by `setup-trivy` to checkout the `trivy` repository                                                                              |
 
 ### Environment variables
 You can use [Trivy environment variables][trivy-env] to set the necessary options (including flags that are not supported by [Inputs](#inputs), such as `--secret-config`).

--- a/action.yaml
+++ b/action.yaml
@@ -119,7 +119,7 @@ runs:
   steps:
     - name: Install Trivy
       if: ${{ inputs.skip-setup-trivy == 'false' }}
-      uses: DmitriyLewen/setup-trivy@fddb6a4fe01a7bd845669cf407127598e53f28f1
+      uses: DmitriyLewen/setup-trivy@2df9f605c29dbee29f7c66a8151e3b97f0874f5d
       with:
         version: ${{ inputs.version }}
         cache: ${{ inputs.cache }}

--- a/action.yaml
+++ b/action.yaml
@@ -122,7 +122,7 @@ runs:
   steps:
     - name: Install Trivy
       if: ${{ inputs.skip-setup-trivy == 'false' }}
-      uses: DmitriyLewen/setup-trivy@34d9f0ee0ca364ca9f822843050fb1013babdb58
+      uses: aquasecurity/setup-trivy@v0.2.2
       with:
         version: ${{ inputs.version }}
         cache: ${{ inputs.cache }}

--- a/action.yaml
+++ b/action.yaml
@@ -111,15 +111,18 @@ inputs:
     description: >
       `token-setup-trivy` is required when `github.token` in invalid for `https://github.com` server.
       See https://github.com/aquasecurity/setup-trivy/?tab=readme-ov-file#install-trivy-with-non-default-token for more details.
+      `token-setup-trivy` is only used to fetch the Trivy repository in `setup-trivy`
     required: false
-    default: ''
+    ## ${{ github.token }} is default value for actions/checkout
+    ## cf. https://github.com/actions/checkout/blob/eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871/action.yml#L24
+    default: ${{ github.token }}
 
 runs:
   using: 'composite'
   steps:
     - name: Install Trivy
       if: ${{ inputs.skip-setup-trivy == 'false' }}
-      uses: DmitriyLewen/setup-trivy@2df9f605c29dbee29f7c66a8151e3b97f0874f5d
+      uses: DmitriyLewen/setup-trivy@34d9f0ee0ca364ca9f822843050fb1013babdb58
       with:
         version: ${{ inputs.version }}
         cache: ${{ inputs.cache }}

--- a/action.yaml
+++ b/action.yaml
@@ -107,16 +107,23 @@ inputs:
     description: 'skip calling the setup-trivy action to install trivy'
     required: false
     default: 'false'
+  token-setup-trivy:
+    description: >
+      `token-setup-trivy` is required when `github.token` in invalid for `https://github.com` server.
+      See https://github.com/aquasecurity/setup-trivy/?tab=readme-ov-file#install-trivy-with-non-default-token for more details.
+    required: false
+    default: ''
 
 runs:
   using: 'composite'
   steps:
     - name: Install Trivy
       if: ${{ inputs.skip-setup-trivy == 'false' }}
-      uses: aquasecurity/setup-trivy@v0.2.1
+      uses: DmitriyLewen/setup-trivy@fddb6a4fe01a7bd845669cf407127598e53f28f1
       with:
         version: ${{ inputs.version }}
         cache: ${{ inputs.cache }}
+        token: ${{ inputs.token-setup-trivy }}
 
     - name: Get current date
       id: date


### PR DESCRIPTION
## Description
There are cases when we need to overwrite token for `actions/checkout` in `setup-trivy`.
e.g. GHES - #418, https://github.com/aquasecurity/setup-trivy/issues/10

So we need to add a `token-setup-trivy` input to add the ability to override the default `token`.

test runs:
- invalid `token-setup-trivy` - https://github.com/DmitriyLewen/test-trivy-action/actions/runs/11493317116
- `token-setup-trivy` with read perms only - https://github.com/DmitriyLewen/test-trivy-action/actions/runs/11493314425
- `token-setup-trivy` is not specified -  https://github.com/DmitriyLewen/test-trivy-action/actions/runs/11493303718

## Related Issues
- Close #418 
- https://github.com/aquasecurity/setup-trivy/issues/10

## Related PRs
- [x] https://github.com/aquasecurity/setup-trivy/pull/12