### PR TITLE
docs: remove ignore-unfixed from IaC scan example

### DIFF
--- a/README.md
+++ b/README.md
@@ -550,7 +550,6 @@ jobs:
           format: 'sarif'
           output: 'trivy-results.sarif'
           exit-code: '1'
-          ignore-unfixed: true
           severity: 'CRITICAL,HIGH'
 
       - name: Upload Trivy scan results to GitHub Security tab


### PR DESCRIPTION
`ignore-unfixed` is only available for vulnerability scanning.