### PR TITLE
fix: Set env var if it differs from actual value

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -161,7 +161,7 @@ runs:
           local default_value="$3"
           local value="${!var_name}"
 
-          if [ ! -z "$input_value" ] && [ "$input_value" != "$default_value" ] || [ "$value" != "$default_value" ]; then
+          if [ ! -z "$input_value" ] && { [ "$input_value" != "$default_value" ] || [ "$value" != "$default_value" ]; }; then
             echo "$var_name=$input_value" >> $GITHUB_ENV
           fi
         }

--- a/action.yaml
+++ b/action.yaml
@@ -159,12 +159,13 @@ runs:
           local var_name="$1"
           local input_value="$2"
           local default_value="$3"
-        
-          if [ ! -z "$input_value" ] && [ "$input_value" != "$default_value" ]; then
+          local value="${!var_name}"
+
+          if [ ! -z "$input_value" ] && [ "$input_value" != "$default_value" ] || [ "$value" != "$default_value" ]; then
             echo "$var_name=$input_value" >> $GITHUB_ENV
           fi
         }
-        
+
         # Set environment variables, handling those with default values
         # cf. https://aquasecurity.github.io/trivy/latest/docs/configuration/#environment-variables
         set_env_var_if_provided "TRIVY_INPUT" "${{ inputs.input }}" ""


### PR DESCRIPTION
# Problem
There is an issue with the current action if you run multiple Trivy actions in a row. It will not respect the inputs as it will not set the env var if the env var if the input value is a different value. However, if the env var already has a different value than the default and you try to set it to a default value, it will not work.

## Scenario
Here is a scenario: You first run Trivy scan with sarif format, and then you run with table format:
```yaml
        - uses: aquasecurity/trivy-action@0.29.0
          with:
            image-ref: node:23.2.0-alpine3.20
            severity: CRITICAL,HIGH
            exit-code: 0
            format: sarif
        - uses: aquasecurity/trivy-action@0.29.0
          with:
            image-ref: node:23.2.0-alpine3.20
            severity: CRITICAL,HIGH
            exit-code: 1
            format: table
```
Then then the second scan will not use format table, as it uses the previously set env var: TRIVY_FORMAT: sarif.

## Tests
Here is a workflow run that shows the issue:
input format: table
https://github.com/david-marconis/trivy-ignore-bug/actions/runs/12065562387/job/33644593462#step:3:6
env TRIVY_FORMAT: sarif
https://github.com/david-marconis/trivy-ignore-bug/actions/runs/12065562387/job/33644593462#step:3:20
log indicating sarif mode:
https://github.com/david-marconis/trivy-ignore-bug/actions/runs/12065562387/job/33644593462#step:3:159

# Fix
The fix is to check if the actual value differs from the wanted value. You could also remove the check if it is the same as the default, IDK if this has any other implications.

Here is a workflow run with the fix implemented:
https://github.com/david-marconis/trivy-ignore-bug/actions/runs/12065669260/job/33644932663#step:3:217

## Fixes
Fixes this issue #438
Might also fix this #435 and #422