### PR TITLE
Update README.md with `permissions` keyword where needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,6 +395,9 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-20.04
+    permissions:
+      contents: read         # permissions needed to be able to run the checkout action
+      security-events: write # permissions needed for the upload-sarif action
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -430,6 +433,9 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-20.04
+    permissions:
+      contents: read         # permissions needed to be able to run the checkout action
+      security-events: write # permissions needed for the upload-sarif action
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -469,6 +475,9 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-20.04
+    permissions:
+      contents: read         # permissions needed to be able to run the checkout action
+      security-events: write # permissions needed for the upload-sarif action
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -503,6 +512,9 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-20.04
+    permissions:
+      contents: read         # permissions needed to be able to run the checkout action
+      security-events: write # permissions needed for the upload-sarif action
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -538,6 +550,9 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-20.04
+    permissions:
+      contents: read         # permissions needed to be able to run the checkout action
+      security-events: write # permissions needed for the upload-sarif action
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -655,6 +670,9 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-20.04
+    permissions:
+      contents: read         # permissions needed to be able to run the checkout action
+      security-events: write # permissions needed for the upload-sarif action
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -691,6 +709,9 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-20.04
+    permissions:
+      contents: read         # permissions needed to be able to run the checkout action
+      security-events: write # permissions needed for the upload-sarif action
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -727,6 +748,9 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-20.04
+    permissions:
+      contents: read         # permissions needed to be able to run the checkout action
+      security-events: write # permissions needed for the upload-sarif action
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -760,6 +784,9 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-20.04
+    permissions:
+      contents: read         # permissions needed to be able to run the checkout action
+      security-events: write # permissions needed for the upload-sarif action
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Adds the permissions keyword with correct config in all examples that push the sarif file to the security tab of the repo. With this update, people will have an easier time implementing the examples and prevent strange issues with "Resource not accessible by integration". 