### PR TITLE
fix: exit 0 when ignorefile doesn't exist

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -22,7 +22,7 @@ if [ -n "${INPUT_TRIVYIGNORES:-}" ]; then
       cat "${f}" >> "$ignorefile"
     else
       echo "ERROR: cannot find ignorefile '${f}'." >&2
-      exit 1
+      exit 0
     fi
   done
   export TRIVY_IGNOREFILE="$ignorefile"


### PR DESCRIPTION
entrypoint.sh fails with exit 1 when ignorefile doesn't exist.
This makes it very difficult to implement top level repo wide ignore rules and per module ignore rules work together.
Changing to exit 0