### PR TITLE
fix: typo in description of an input for action.yaml

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -8,7 +8,7 @@ inputs:
     required: false
     default: 'image'
   image-ref:
-    description: 'image reference(for backward compatibility)'
+    description: 'image reference (for backward compatibility)'
     required: false
   input:
     description: 'reference of tar file to scan'


### PR DESCRIPTION
Small typo found in the description for an input in the `action.yaml` file.