### PR TITLE
Fix Trivy action inputs leaking between invocations (#422)

### DIFF
--- a/README.md
+++ b/README.md
@@ -856,6 +856,13 @@ Following inputs can be used as `step.with` keys:
 ### Environment variables
 You can use [Trivy environment variables][trivy-env] to set the necessary options (including flags that are not supported by [Inputs](#inputs), such as `--secret-config`).
 
+**NB** In some older versions of the Action there was a bug that caused inputs from one call to the Action to leak 
+over to subsequent calls to the Action.  This could cause workflows that call the Action multiple times e.g. to run 
+multiple scans, or the same scans with different output formats, to not produce the desired output.  You can see if this
+is the case by looking at the GitHub Actions step information, if the `env` section shown in your Actions output 
+contains `TRIVY_*` environment variables you did not explicitly set then you may be affected by this bug and should 
+upgrade to the latest Action version.
+
 ### Trivy config file
 When using the `trivy-config` [Input](#inputs), you can set options using the [Trivy config file][trivy-config] (including flags that are not supported by [Inputs](#inputs), such as `--secret-config`).
 

--- a/action.yaml
+++ b/action.yaml
@@ -179,7 +179,7 @@ runs:
           local input_value="$2"
           local default_value="$3"
         
-          if [ ! -z "$input_value" && "$input_value" != "$default_value" ]; then
+          if [ ! -z "$input_value" ] && [ "$input_value" != "$default_value" ]; then
             # If action was provided with explicit input by the caller set that
             echo "export $var_name=$input_value" >> trivy_envs.txt
           fi

--- a/action.yaml
+++ b/action.yaml
@@ -194,6 +194,13 @@ runs:
         set_env_var_if_provided "TRIVY_TF_VARS" "${{ inputs.tf-vars }}" ""
         set_env_var_if_provided "TRIVY_DOCKER_HOST" "${{ inputs.docker-host }}" ""
 
+    - name: Display Env variables
+      # Only when Actions Debug Logging enabled
+      if: ${{ runner.debug == '1' }}
+      shell: bash
+      run: |
+        cat trivy_envs.txt
+
     - name: Run Trivy
       shell: bash
       run: entrypoint.sh

--- a/action.yaml
+++ b/action.yaml
@@ -162,26 +162,26 @@ runs:
         # This limitation affects how we handle default values and empty inputs.
         # For more information, see: https://github.com/actions/runner/issues/924
 
-        # Function to set environment variable only if the input is provided, or a default required
+        # The following logic implements the configuration priority described in the README:
+        #
+        # Inputs
+        # Environment Variables
+        # Config File
+        # Defaults
+        #
+        # As noted above defaults are awkward to handle as GitHub Actions will inject those values as the input
+        # if the caller doesn't provide them, thus if the input matches the default we don't set it as we
+        # can't tell the difference.  Plus if we did set it when it was the default value then it could potentially 
+        # override an external environment variable, or something in the callers configuration file, which then wouldn't 
+        # match the configuration priority that is documented.
         set_env_var_if_provided() {
           local var_name="$1"
           local input_value="$2"
           local default_value="$3"
-          local external_value="${!var_name}"
         
-          if [ -n "$external_value" ]; then
-            # If action had this value already set in the configured environment variables honour the existing
-            # environment variable
-            # In this case don't need to export it as it already exists in the environment
-            return
-          elif [ ! -z "$input_value" ]; then
+          if [ ! -z "$input_value" && "$input_value" != "$default_value" ]; then
             # If action was provided with explicit input by the caller set that
             echo "export $var_name=$input_value" >> trivy_envs.txt
-          elif [ ! -z "$default_value" ]; then
-            # Otherwise if the action defines a default value then set that 
-            # This is necessary because in some cases the Actions defined default may not align
-            # with the trivy CLIs default
-            echo "export $var_name=$default_value" >> trivy_envs.txt
           fi
         }
         

--- a/action.yaml
+++ b/action.yaml
@@ -192,6 +192,10 @@ runs:
         set_env_var_if_provided "TRIVY_TF_VARS" "${{ inputs.tf-vars }}" ""
         set_env_var_if_provided "TRIVY_DOCKER_HOST" "${{ inputs.docker-host }}" ""
 
+    - name: test
+      shell: bash
+      run: cat trivy_envs.txt
+
     - name: Run Trivy
       shell: bash
       run: entrypoint.sh

--- a/action.yaml
+++ b/action.yaml
@@ -146,7 +146,7 @@ runs:
       run: |
         echo "Listing contents of inputs.cache-dir"
         ls -alh ${{ inputs.cache-dir }}
-        cat ${{ inputs.cache-dir }}/trivy/db/metadata.json
+        cat ${{ inputs.cache-dir }}/db/metadata.json
 
     - name: Set GitHub Path
       run: echo "$GITHUB_ACTION_PATH" >> $GITHUB_PATH

--- a/action.yaml
+++ b/action.yaml
@@ -141,24 +141,19 @@ runs:
         key: cache-trivy-${{ steps.date.outputs.date }}
         restore-keys: cache-trivy-
 
-    - name: test
-      shell: bash
-      run: |
-        echo "Listing contents of inputs.cache-dir"
-        ls -alh ${{ inputs.cache-dir }}
-        cat ${{ inputs.cache-dir }}/db/metadata.json
-
     - name: Set GitHub Path
       run: echo "$GITHUB_ACTION_PATH" >> $GITHUB_PATH
       shell: bash
       env:
         GITHUB_ACTION_PATH: ${{ github.action_path }}
 
-    - name: Create file with trivy envs
+    # Create and Clear Trivy Envs file
+    # See #422 for context
+    - name: Clear Trivy Envs file
       shell: bash
       run: |
-        # Create/clear file with Trivy envs to keep envs within this action and avoid env leaks
-        > trivy_envs.txt
+        rm -f trivy_envs.txt
+        touch trivy_envs.txt
 
     - name: Set Trivy environment variables
       shell: bash
@@ -199,10 +194,6 @@ runs:
         set_env_var_if_provided "TRIVY_TF_VARS" "${{ inputs.tf-vars }}" ""
         set_env_var_if_provided "TRIVY_DOCKER_HOST" "${{ inputs.docker-host }}" ""
 
-    - name: test
-      shell: bash
-      run: cat trivy_envs.txt
-
     - name: Run Trivy
       shell: bash
       run: entrypoint.sh
@@ -219,3 +210,11 @@ runs:
 
         # For Trivy
         TRIVY_CACHE_DIR: ${{ inputs.cache-dir }} # Always set
+
+    # Remove Trivy envs to keep envs within this action and avoid env leaks
+    # See #422 for context
+    - name: Remove Trivy Envs file
+      if: ${{ always() }}
+      shell: bash
+      run: |
+        rm -f trivy_envs.txt

--- a/action.yaml
+++ b/action.yaml
@@ -147,6 +147,12 @@ runs:
       env:
         GITHUB_ACTION_PATH: ${{ github.action_path }}
 
+    - name: Create file with trivy envs
+      shell: bash
+      run: |
+        # Create/clear file with Trivy envs to keep envs within this action and avoid env leaks
+        > trivy_envs.txt
+
     - name: Set Trivy environment variables
       shell: bash
       run: |
@@ -161,7 +167,7 @@ runs:
           local default_value="$3"
         
           if [ ! -z "$input_value" ] && [ "$input_value" != "$default_value" ]; then
-            echo "$var_name=$input_value" >> $GITHUB_ENV
+            echo "$var_name=$input_value" >> trivy_envs.txt
           fi
         }
         

--- a/action.yaml
+++ b/action.yaml
@@ -162,15 +162,25 @@ runs:
         # This limitation affects how we handle default values and empty inputs.
         # For more information, see: https://github.com/actions/runner/issues/924
 
-        # Function to set environment variable only if the input is provided and different from default
+        # Function to set environment variable only if the input is provided, or a default required
         set_env_var_if_provided() {
           local var_name="$1"
           local input_value="$2"
           local default_value="$3"
+          local external_value="${!var_name}"
         
-          if [ ! -z "$input_value" ]; then
+          if [ -n "$external_value" ]; then
+            # If action had this value already set in the configured environment variables honour the existing
+            # environment variable
+            # In this case don't need to export it as it already exists in the environment
+            return
+          elif [ ! -z "$input_value" ]; then
+            # If action was provided with explicit input by the caller set that
             echo "export $var_name=$input_value" >> trivy_envs.txt
           elif [ ! -z "$default_value" ]; then
+            # Otherwise if the action defines a default value then set that 
+            # This is necessary because in some cases the Actions defined default may not align
+            # with the trivy CLIs default
             echo "export $var_name=$default_value" >> trivy_envs.txt
           fi
         }
@@ -195,13 +205,6 @@ runs:
         set_env_var_if_provided "TRIVY_CONFIG" "${{ inputs.trivy-config }}" ""
         set_env_var_if_provided "TRIVY_TF_VARS" "${{ inputs.tf-vars }}" ""
         set_env_var_if_provided "TRIVY_DOCKER_HOST" "${{ inputs.docker-host }}" ""
-
-    - name: Display Env variables
-      # Only when Actions Debug Logging enabled
-      if: ${{ runner.debug == '1' }}
-      shell: bash
-      run: |
-        cat trivy_envs.txt
 
     - name: Run Trivy
       shell: bash

--- a/action.yaml
+++ b/action.yaml
@@ -168,8 +168,10 @@ runs:
           local input_value="$2"
           local default_value="$3"
         
-          if [ ! -z "$input_value" ] && [ "$input_value" != "$default_value" ]; then
+          if [ ! -z "$input_value" ]; then
             echo "export $var_name=$input_value" >> trivy_envs.txt
+          elif [ ! -z "$default_value" ]; then
+            echo "export $var_name=$default_value" >> trivy_envs.txt
           fi
         }
         

--- a/action.yaml
+++ b/action.yaml
@@ -141,6 +141,13 @@ runs:
         key: cache-trivy-${{ steps.date.outputs.date }}
         restore-keys: cache-trivy-
 
+    - name: test
+      shell: bash
+      run: |
+        echo "Listing contents of inputs.cache-dir"
+        ls -alh ${{ inputs.cache-dir }}
+        cat ${{ inputs.cache-dir }}/trivy/db/metadata.json
+
     - name: Set GitHub Path
       run: echo "$GITHUB_ACTION_PATH" >> $GITHUB_PATH
       shell: bash

--- a/action.yaml
+++ b/action.yaml
@@ -167,7 +167,7 @@ runs:
           local default_value="$3"
         
           if [ ! -z "$input_value" ] && [ "$input_value" != "$default_value" ]; then
-            echo "$var_name=$input_value" >> trivy_envs.txt
+            echo "export $var_name=$input_value" >> trivy_envs.txt
           fi
         }
         

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -euo pipefail
 
+# Read TRIVY_* envs from file
+source trivy_envs.txt
+
 # Set artifact reference
 scanType="${INPUT_SCAN_TYPE:-image}"
 scanRef="${INPUT_SCAN_REF:-.}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # Read TRIVY_* envs from file
-export TRIVY_FORMAT="sarif"
+source ./trivy_envs.txt
 
 echo "$TRIVY_FORMAT"
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # Read TRIVY_* envs from file
-source trivy_envs.txt
+source ./trivy_envs.txt
 
 # Set artifact reference
 scanType="${INPUT_SCAN_TYPE:-image}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,7 +5,9 @@ set -euo pipefail
 # injects those into subsequent job steps which means inputs from one trivy-action invocation were leaking over to 
 # any subsequent invocation which led to unexpected/undesireable behaviour from a user perspective
 # See #422 for more context around this
-source ./trivy_envs.txt
+if [ -f ./trivy_envs.txt ]; then
+  source ./trivy_envs.txt
+fi
 
 # Set artifact reference
 scanType="${INPUT_SCAN_TYPE:-image}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # Read TRIVY_* envs from file
-source ./trivy_envs.txt
+export TRIVY_FORMAT="sarif"
 
 echo "$TRIVY_FORMAT"
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,10 +1,9 @@
 #!/bin/bash
 set -euo pipefail
 
+echo "export TRIVY_DEBUG=true" >> ./trivy_envs.txt
 # Read TRIVY_* envs from file
 source ./trivy_envs.txt
-
-echo "$TRIVY_FORMAT"
 
 # Set artifact reference
 scanType="${INPUT_SCAN_TYPE:-image}"
@@ -42,6 +41,8 @@ if [ "${TRIVY_FORMAT:-}" = "sarif" ]; then
     echo "Building SARIF report"
   fi
 fi
+
+env | grep TRIVY
 
 # Run Trivy
 cmd=(trivy "$scanType" "$scanRef")

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 set -euo pipefail
 
-echo "export TRIVY_DEBUG=true" >> ./trivy_envs.txt
 # Read TRIVY_* envs from file, previously they were written to the GITHUB_ENV file but GitHub Actions automatically 
 # injects those into subsequent job steps which means inputs from one trivy-action invocation were leaking over to 
 # any subsequent invocation which led to unexpected/undesireable behaviour from a user perspective

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,10 @@
 set -euo pipefail
 
 echo "export TRIVY_DEBUG=true" >> ./trivy_envs.txt
-# Read TRIVY_* envs from file
+# Read TRIVY_* envs from file, previously they were written to the GITHUB_ENV file but GitHub Actions automatically 
+# injects those into subsequent job steps which means inputs from one trivy-action invocation were leaking over to 
+# any subsequent invocation which led to unexpected/undesireable behaviour from a user perspective
+# See #422 for more context around this
 source ./trivy_envs.txt
 
 # Set artifact reference
@@ -41,8 +44,6 @@ if [ "${TRIVY_FORMAT:-}" = "sarif" ]; then
     echo "Building SARIF report"
   fi
 fi
-
-env | grep TRIVY
 
 # Run Trivy
 cmd=(trivy "$scanType" "$scanRef")

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 # Read TRIVY_* envs from file
 source ./trivy_envs.txt
 
+echo "$TRIVY_FORMAT"
+
 # Set artifact reference
 scanType="${INPUT_SCAN_TYPE:-image}"
 scanRef="${INPUT_SCAN_REF:-.}"


### PR DESCRIPTION
As discussed in #422 the current way that the Trivy action injects the GitHub Actions inputs to `trivy` is by adding these to the `GITHUB_ENV` file which is then used to populate the environment for all subsequent job steps.  This leads to a problem where a subsequent call to `aquasecurity/trivy-action` may incorrectly pick up inputs from a previous call because those previous inputs are already set in the environment file, and the action only sets those environment variables to new values if the new inputs differ from the defaults.

This PR takes an approach that @DmitriyLewen was already developing in his fork and finishes it up ready for review.  Basically instead of writing the inputs to the `GITHUB_ENV` file it writes them, in the form of `export <var>=<value>` statements to a temporary `trivy_envs.txt` file, and has the `entrypoint.sh` script `source` that file.  The file is cleaned up as part of the action running.  This ensures that inputs from one call to the action cannot be leaked into a subsequent call to the action.

Note that supersedes another approach proposed in #437 since as [discussed there](https://github.com/aquasecurity/trivy-action/pull/437#issuecomment-2516423537) that approach still potentially leaks the Trivy action inputs across job steps.  As noted in that PR the alternative approach in this PR also likely fixes other related issues #438 and #435

# Testing

- Have added a BATS test in this repository that verifies that the `entrypoint.sh` script does load the `trivy_envs.txt` file correctly
- Have been testing my fork against my $dayjob workflows where we were encountering this issue with input leakage leading to Trivy scans not generating output in our desired formats.  With the fork those workflows are now generating the correct output, and GitHub Actions debug logging has been used to confirm that inputs are no longer being set in the environment for subsequent `trivy-action` invocations as we had previously [noted](https://github.com/aquasecurity/trivy-action/issues/422#issuecomment-2747837233).  Now the only env variables we are seeing passed into `trivy-action` are the ones we explicitly add ourselves.
- Tests repository, again based on @DmitriyLewen's earlier work, that compares behaviour across `master`, the previous proposed fix and my proposed fix - https://github.com/rvesse/test-trivy-action/actions/runs/14216797998

E.g. With current `master`, environment leakage occurs:

![Current Master with Env Leakage](https://github.com/user-attachments/assets/6a515e38-11d8-452a-91f7-8d633dbf223d)

With the changes from this branch, environment leakage no longer occurs and all inputs are honoured as expected:

![Example Action Invocation with No Env Leakage](https://github.com/user-attachments/assets/da30df42-becc-41a0-9c58-560cb3e35f1e)
