### PR TITLE
Pin aquasecuriy/setup-trivy to hash instead of tag

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -126,8 +126,7 @@ runs:
       # "allowing select actions" feature can be used to whitelist the dependent action by a hash.
       # This is needed since some organizations have a policy to only allow pinned 3rd party actions to 
       # be used.
-      # ff1b8b060f23b650436d419b5e13f67f5d4c3087 is equal to v0.2.2
-      uses: aquasecurity/setup-trivy@ff1b8b060f23b650436d419b5e13f67f5d4c3087
+      uses: aquasecurity/setup-trivy@ff1b8b060f23b650436d419b5e13f67f5d4c3087 # equivalent to `v0.2.2`
       with:
         version: ${{ inputs.version }}
         cache: ${{ inputs.cache }}

--- a/action.yaml
+++ b/action.yaml
@@ -122,7 +122,11 @@ runs:
   steps:
     - name: Install Trivy
       if: ${{ inputs.skip-setup-trivy == 'false' }}
-      uses: aquasecurity/setup-trivy@v0.2.2
+      # Pin to hash instead of tag for aquasecurity/setup-trivy action so that GitHub Actions 
+      # "allowing select actions" feature can be used to whitelist the dependent action by a hash.
+      # This is needed since some organizations have a policy to only allow pinned 3rd party actions to 
+      # be used.
+      uses: aquasecurity/setup-trivy@ff1b8b060f23b650436d419b5e13f67f5d4c3087
       with:
         version: ${{ inputs.version }}
         cache: ${{ inputs.cache }}

--- a/action.yaml
+++ b/action.yaml
@@ -126,6 +126,7 @@ runs:
       # "allowing select actions" feature can be used to whitelist the dependent action by a hash.
       # This is needed since some organizations have a policy to only allow pinned 3rd party actions to 
       # be used.
+      # ff1b8b060f23b650436d419b5e13f67f5d4c3087 is equal to v0.2.2
       uses: aquasecurity/setup-trivy@ff1b8b060f23b650436d419b5e13f67f5d4c3087
       with:
         version: ${{ inputs.version }}


### PR DESCRIPTION
Fixes #423

Pin `aquasecurity/setup-trivy` to hash instead of a tag so that GitHub Actions
["allowing select actions" feature](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#allowing-select-actions-and-reusable-workflows-to-run) can be used to whitelist the dependent action by a hash.
This is needed since some organizations have a policy to only allow pinned 3rd party actions to
be used. ["Pin actions to a full length commit SHA"](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) is recommended by GitHub and many organizations follow this best practice.

 It's not currently possible to use trivy-action since the dependent action isn't pinned. This PR fixes that. More details in #423.