### PR TITLE
doc: correct sbom fs scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -590,7 +590,7 @@ jobs:
           scan-type: 'fs'
           format: 'github'
           output: 'dependency-results.sbom.json'
-          image-ref: '.'
+          scan-ref: '.'
           github-pat: ${{ secrets.GITHUB_TOKEN }} # or ${{ secrets.github_pat_name }} if you're using a PAT
 ```
 


### PR DESCRIPTION
Fixing error in the README.md. I was confused that the `image-ref: '.'` was specified for `scan-type: 'fs'`. I believe the intent is to set `scan-ref: '.'`.