### PR TITLE
fix: scans not ignoring definitions from trivyignores input

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,7 +18,7 @@ fi
 
 # Handle trivy ignores
 if [ -n "${INPUT_TRIVYIGNORES:-}" ]; then
-  ignorefile="./trivyignores"
+  ignorefile="./trivyignores.yaml"
 
   # Clear the ignore file if it exists, or create a new empty file
   : > "$ignorefile"


### PR DESCRIPTION
Files passed into the `trivyignores` input with `.yaml` work as expected but all other extensions do not work.

`aquasecurity/trivy-action` places the contents of all ignore files passed in the `trivyignores` input into [a file called `trivyignores`](https://github.com/aquasecurity/trivy-action/blob/77137e9dc3ab1b329b7c8a38c2eb7475850a14e8/entrypoint.sh#L21C17-L21C29) which is then passed to the actually trivy binary as an env variable. 

Since this unexpected behavior is occurring in the trivy binary, this pr is simply adding a work around.