### PR TITLE
Update setup-trivy action to version v0.2.4

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -126,7 +126,7 @@ runs:
       # "allowing select actions" feature can be used to whitelist the dependent action by a hash.
       # This is needed since some organizations have a policy to only allow pinned 3rd party actions to 
       # be used.
-      uses: aquasecurity/setup-trivy@ff1b8b060f23b650436d419b5e13f67f5d4c3087 # equivalent to `v0.2.2`
+      uses: aquasecurity/setup-trivy@e6c2c5e321ed9123bda567646e2f96565e34abe1 # equivalent to `v0.2.4`
       with:
         version: ${{ inputs.version }}
         cache: ${{ inputs.cache }}


### PR DESCRIPTION
Bump setup-trivy to latest release so only pinned actions are used.

Unfortunately, #480 by itself wasn't enough to fix it.
