### PR TITLE
ci: use setup-bats in bump-trivy workflow

### DIFF
--- a/.github/workflows/bump-trivy.yaml
+++ b/.github/workflows/bump-trivy.yaml
@@ -22,7 +22,13 @@ jobs:
       - name: Update Trivy versions
         run: make bump-trivy
 
+      - name: Setup Bats and bats libs
+        id: setup-bats
+        uses: bats-core/bats-action@3.0.1
+
       - name: Update golden files
+        env:
+          BATS_LIB_PATH: ${{ steps.setup-bats.outputs.lib-path }}
         run: make update-golden
 
       - name: Create PR

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,7 +16,8 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup Bats and bats libs
-        uses: bats-core/bats-action@2.0.0
+        id: setup-bats
+        uses: bats-core/bats-action@3.0.1
 
       - name: Install Trivy
         run: |
@@ -24,8 +25,6 @@ jobs:
           trivy --version
 
       - name: Test
-        run: bats --recursive --timing --verbose-run .
         env:
-          TRIVY_CACHE_DIR: .cache
-          TRIVY_DISABLE_VEX_NOTICE: true
-          TRIVY_DEBUG: true
+          BATS_LIB_PATH: ${{ steps.setup-bats.outputs.lib-path }}
+        run: make test

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 OS := $(shell uname)
 SED = sed
-BATS_LIB_PATH = /usr/local/lib/ 
+BATS_LIB_PATH ?= /usr/local/lib/ 
 
 ifeq ($(OS), Darwin)
 SED = gsed
-BATS_LIB_PATH = /opt/homebrew/lib
+BATS_LIB_PATH ?= /opt/homebrew/lib
 endif
 
 BATS_ENV := BATS_LIB_PATH=$(BATS_LIB_PATH) \


### PR DESCRIPTION
This PR adds a `setup-bats` step to the `bump-trivy` workflow to install Bats, which is required for updating golden files. The `lib-path` output is now used in all workflows to specify the path to the libraries. In the Makefile, the `BATS_LIB_PATH` environment variable is set only if it is not already defined, to avoid overwriting the value provided by CI.

Fixes: https://github.com/aquasecurity/trivy-action/actions/runs/20030705175/job/57438851129