### PR TITLE
ci: install trivy in bump-trivy workflow and update tests

### DIFF
--- a/.github/workflows/bump-trivy.yaml
+++ b/.github/workflows/bump-trivy.yaml
@@ -26,6 +26,11 @@ jobs:
         id: setup-bats
         uses: bats-core/bats-action@3.0.1
 
+      - name: Install Trivy
+        run: |
+          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v${{ inputs.trivy_version }}
+          trivy --version
+
       - name: Update golden files
         env:
           BATS_LIB_PATH: ${{ steps.setup-bats.outputs.lib-path }}

--- a/.github/workflows/bump-trivy.yaml
+++ b/.github/workflows/bump-trivy.yaml
@@ -15,11 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      
-      - name: Set new version from input
-        run: echo "NEW_VERSION=${{ inputs.trivy_version }}" >> $GITHUB_ENV
 
       - name: Update Trivy versions
+        env:
+          NEW_VERSION: ${{ inputs.trivy_version }}
         run: make bump-trivy
 
       - name: Setup Bats and bats libs
@@ -35,6 +34,11 @@ jobs:
         env:
           BATS_LIB_PATH: ${{ steps.setup-bats.outputs.lib-path }}
         run: make update-golden
+
+      - name: Run tests
+        env:
+          BATS_LIB_PATH: ${{ steps.setup-bats.outputs.lib-path }}
+        run: make test
 
       - name: Create PR
         id: create-pr

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,11 @@
 OS := $(shell uname)
-SED = sed
-BATS_LIB_PATH ?= /usr/local/lib/ 
 
 ifeq ($(OS), Darwin)
-SED = gsed
-BATS_LIB_PATH ?= /opt/homebrew/lib
+  SED = gsed
+  BATS_LIB_PATH ?= /opt/homebrew/lib
+else
+  SED = sed
+  BATS_LIB_PATH ?= /usr/local/lib/
 endif
 
 BATS_ENV := BATS_LIB_PATH=$(BATS_LIB_PATH) \

--- a/test/test.bats
+++ b/test/test.bats
@@ -5,6 +5,7 @@ setup_file() {
   export TRIVY_DB_REPOSITORY=ghcr.io/${owner}/trivy-db-act:latest
   export TRIVY_JAVA_DB_REPOSITORY=ghcr.io/${owner}/trivy-java-db-act:latest
   export TRIVY_CHECKS_BUNDLE_REPOSITORY=ghcr.io/${owner}/trivy-checks-act:latest
+  export TRIVY_LIST_ALL_PKGS=false
 }
 
 setup() {
@@ -16,7 +17,7 @@ setup() {
 function remove_json_fields() {
   local file="$1"
   if [[ "$file" == *.json ]]; then
-      jq 'del(.CreatedAt)' "$file" > tmp && mv tmp "$file"
+      jq 'del(.CreatedAt, .ReportID)' "$file" > tmp && mv tmp "$file"
   fi
 }
 


### PR DESCRIPTION

This PR introduces several fixes and improvements to the testing workflow:

- Adds a step to install Trivy, which was missing in the previous PR.
- Tests are now run after updating the golden files to detect nondeterministic fields. For example, if tests fail after updating the golden files, it indicates discrepancies between the results, which may be caused by fields whose values change between runs.
- Removed the `ReportID` field, which is unique for each run (see https://github.com/aquasecurity/trivy/issues/9669).
- Disabled the `list-all-pkgs` flag, which is now enabled by default (see https://github.com/aquasecurity/trivy/pull/9510).

The `ArtifactID` and `Fingerprint` fields were left unchanged, as they are unique per artifact and do not affect test stability.

Test run - https://github.com/nikpivkin/trivy-action/actions/runs/20091355885
Opened PR - https://github.com/nikpivkin/trivy-action/pull/13