### PR TITLE
update workflow and action versions

### DIFF
--- a/workflow.yml
+++ b/workflow.yml
@@ -7,10 +7,12 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Build an image from Dockerfile
         run: |
@@ -29,6 +31,6 @@ jobs:
           severity: 'CRITICAL,HIGH'
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
- bump runner verison of ubuntu from 20.04 to 24.04
- bump version of  github/codeql-action/upload-sarif from v3 to v4
- bump version of  actions/checkout from v3 to v6