### PR TITLE
ci(test): add zizmor security linter for GitHub Actions

### DIFF
--- a/.github/workflows/bump-trivy.yaml
+++ b/.github/workflows/bump-trivy.yaml
@@ -14,7 +14,7 @@ jobs:
   bump:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Update Trivy versions
         env:
@@ -23,7 +23,7 @@ jobs:
 
       - name: Setup Bats and bats libs
         id: setup-bats
-        uses: bats-core/bats-action@3.0.1
+        uses: bats-core/bats-action@42fcc8700f773c075a16a90eb11674c0318ad507 # 3.0.1
 
       - name: Install Trivy
         run: |
@@ -42,7 +42,7 @@ jobs:
 
       - name: Create PR
         id: create-pr
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@4e1beaa7521e8b457b572c090b25bd3db56bf1c5 # v5
         with:
           token: ${{ secrets.ORG_REPO_TOKEN }}
           title: "chore(deps): Update trivy to v${{ inputs.trivy_version }}"

--- a/.github/workflows/bump-trivy.yaml
+++ b/.github/workflows/bump-trivy.yaml
@@ -13,8 +13,12 @@ run-name: Bump trivy to v${{ inputs.trivy_version }}
 jobs:
   bump:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Update Trivy versions
         env:
@@ -26,8 +30,10 @@ jobs:
         uses: bats-core/bats-action@42fcc8700f773c075a16a90eb11674c0318ad507 # 3.0.1
 
       - name: Install Trivy
+        env:
+          TRIVY_VERSION: ${{ inputs.trivy_version }}
         run: |
-          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v${{ inputs.trivy_version }}
+          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin "v${TRIVY_VERSION}"
           trivy --version
 
       - name: Update golden files
@@ -54,6 +60,9 @@ jobs:
           delete-branch: true
 
       - name: Check outputs
+        env:
+          PR_NUMBER: ${{ steps.create-pr.outputs.pull-request-number }}
+          PR_URL: ${{ steps.create-pr.outputs.pull-request-url }}
         run: |
-          echo "Pull Request Number - ${{ steps.create-pr.outputs.pull-request-number }}"
-          echo "Pull Request URL - ${{ steps.create-pr.outputs.pull-request-url }}"
+          echo "Pull Request Number - ${PR_NUMBER}"
+          echo "Pull Request URL - ${PR_URL}"

--- a/.github/workflows/sync-trivy-checks.yaml
+++ b/.github/workflows/sync-trivy-checks.yaml
@@ -10,13 +10,13 @@ jobs:
   sync-trivy-checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: setup-oras
-        uses: oras-project/setup-oras@v1.2.3
+        uses: oras-project/setup-oras@8d34698a59f5ffe24821f0b48ab62a3de8b64b20 # v1.2.3
 
       - name: Login to GitHub Packages Container registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/sync-trivy-checks.yaml
+++ b/.github/workflows/sync-trivy-checks.yaml
@@ -9,8 +9,13 @@ env:
 jobs:
   sync-trivy-checks:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: setup-oras
         uses: oras-project/setup-oras@8d34698a59f5ffe24821f0b48ab62a3de8b64b20 # v1.2.3
@@ -24,4 +29,4 @@ jobs:
 
       - name: Copy Trivy Checks
         run: |
-          oras cp ghcr.io/aquasecurity/trivy-checks:2 ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          oras cp ghcr.io/aquasecurity/trivy-checks:2 "${REGISTRY}/${IMAGE_NAME}:latest"

--- a/.github/workflows/sync-trivy-db.yaml
+++ b/.github/workflows/sync-trivy-db.yaml
@@ -10,13 +10,13 @@ jobs:
   sync-trivy-db:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: setup-oras
-        uses: oras-project/setup-oras@v1.2.3
+        uses: oras-project/setup-oras@8d34698a59f5ffe24821f0b48ab62a3de8b64b20 # v1.2.3
 
       - name: Login to GitHub Packages Container registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/sync-trivy-db.yaml
+++ b/.github/workflows/sync-trivy-db.yaml
@@ -9,8 +9,13 @@ env:
 jobs:
   sync-trivy-db:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: setup-oras
         uses: oras-project/setup-oras@8d34698a59f5ffe24821f0b48ab62a3de8b64b20 # v1.2.3
@@ -24,4 +29,4 @@ jobs:
 
       - name: Copy Trivy DB
         run: |
-          oras cp ghcr.io/aquasecurity/trivy-db:2 ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          oras cp ghcr.io/aquasecurity/trivy-db:2 "${REGISTRY}/${IMAGE_NAME}:latest"

--- a/.github/workflows/sync-trivy-java-db.yaml
+++ b/.github/workflows/sync-trivy-java-db.yaml
@@ -10,13 +10,13 @@ jobs:
   sync-trivy-db:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: setup-oras
-        uses: oras-project/setup-oras@v1.2.3
+        uses: oras-project/setup-oras@8d34698a59f5ffe24821f0b48ab62a3de8b64b20 # v1.2.3
 
       - name: Login to GitHub Packages Container registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/sync-trivy-java-db.yaml
+++ b/.github/workflows/sync-trivy-java-db.yaml
@@ -9,8 +9,13 @@ env:
 jobs:
   sync-trivy-db:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: setup-oras
         uses: oras-project/setup-oras@8d34698a59f5ffe24821f0b48ab62a3de8b64b20 # v1.2.3
@@ -24,4 +29,4 @@ jobs:
 
       - name: Copy Trivy Java DB
         run: |
-          oras cp ghcr.io/aquasecurity/trivy-java-db:1 ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          oras cp ghcr.io/aquasecurity/trivy-java-db:1 "${REGISTRY}/${IMAGE_NAME}:latest"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Run zizmor
         uses: zizmorcore/zizmor-action@0dce2577a4760a2749d8cfb7a84b7d5585ebcb7d # v0.5.0
@@ -23,11 +23,11 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Bats and bats libs
         id: setup-bats
-        uses: bats-core/bats-action@3.0.1
+        uses: bats-core/bats-action@42fcc8700f773c075a16a90eb11674c0318ad507 # 3.0.1
 
       - name: Install Trivy
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,6 +10,14 @@ env:
   BATS_LIB_PATH: '/usr/lib/'
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@0dce2577a4760a2749d8cfb7a84b7d5585ebcb7d # v0.5.0
+
   test:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,6 +17,8 @@ jobs:
 
       - name: Run zizmor
         uses: zizmorcore/zizmor-action@0dce2577a4760a2749d8cfb7a84b7d5585ebcb7d # v0.5.0
+        with:
+          advanced-security: false
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,8 +12,12 @@ env:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Run zizmor
         uses: zizmorcore/zizmor-action@0dce2577a4760a2749d8cfb7a84b7d5585ebcb7d # v0.5.0
@@ -22,8 +26,12 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Setup Bats and bats libs
         id: setup-bats

--- a/action.yaml
+++ b/action.yaml
@@ -146,8 +146,7 @@ runs:
         restore-keys: cache-trivy-
 
     - name: Set GitHub Path
-      # zizmor: ignore[github-env] - github.action_path is controlled by GitHub, not user input
-      run: echo "$GITHUB_ACTION_PATH" >> $GITHUB_PATH
+      run: echo "$GITHUB_ACTION_PATH" >> $GITHUB_PATH # zizmor: ignore[github-env]
       shell: bash
       env:
         GITHUB_ACTION_PATH: ${{ github.action_path }}

--- a/action.yaml
+++ b/action.yaml
@@ -146,6 +146,7 @@ runs:
         restore-keys: cache-trivy-
 
     - name: Set GitHub Path
+      # zizmor: ignore[github-env] - github.action_path is controlled by GitHub, not user input
       run: echo "$GITHUB_ACTION_PATH" >> $GITHUB_PATH
       shell: bash
       env:
@@ -161,6 +162,25 @@ runs:
 
     - name: Set Trivy environment variables
       shell: bash
+      env:
+        INPUT_INPUT: ${{ inputs.input }}
+        INPUT_EXIT_CODE: ${{ inputs.exit-code }}
+        INPUT_IGNORE_UNFIXED: ${{ inputs.ignore-unfixed }}
+        INPUT_VULN_TYPE: ${{ inputs.vuln-type }}
+        INPUT_SEVERITY: ${{ inputs.severity }}
+        INPUT_FORMAT: ${{ inputs.format }}
+        INPUT_TEMPLATE: ${{ inputs.template }}
+        INPUT_OUTPUT: ${{ inputs.output }}
+        INPUT_SKIP_DIRS: ${{ inputs.skip-dirs }}
+        INPUT_SKIP_FILES: ${{ inputs.skip-files }}
+        INPUT_TIMEOUT: ${{ inputs.timeout }}
+        INPUT_IGNORE_POLICY: ${{ inputs.ignore-policy }}
+        INPUT_HIDE_PROGRESS: ${{ inputs.hide-progress }}
+        INPUT_LIST_ALL_PKGS: ${{ inputs.list-all-pkgs }}
+        INPUT_SCANNERS: ${{ inputs.scanners }}
+        INPUT_TRIVY_CONFIG: ${{ inputs.trivy-config }}
+        INPUT_TF_VARS: ${{ inputs.tf-vars }}
+        INPUT_DOCKER_HOST: ${{ inputs.docker-host }}
       run: |
         # Note: There is currently no way to distinguish between undefined variables and empty strings in GitHub Actions.
         # This limitation affects how we handle default values and empty inputs.
@@ -175,41 +195,41 @@ runs:
         #
         # As noted above defaults are awkward to handle as GitHub Actions will inject those values as the input
         # if the caller doesn't provide them, thus if the input matches the default we don't set it as we
-        # can't tell the difference.  Plus if we did set it when it was the default value then it could potentially 
-        # override an external environment variable, or something in the callers configuration file, which then wouldn't 
+        # can't tell the difference.  Plus if we did set it when it was the default value then it could potentially
+        # override an external environment variable, or something in the callers configuration file, which then wouldn't
         # match the configuration priority that is documented.
         set_env_var_if_provided() {
           local var_name="$1"
           local input_value="$2"
           local default_value="$3"
-        
+
           if [ -n "$input_value" ] && [ "$input_value" != "$default_value" ]; then
             # If action was provided with explicit input by the caller set that
             # Use printf %q to safely escape special characters and prevent command injection
             printf 'export %s=%q\n' "$var_name" "$input_value" >> trivy_envs.txt
           fi
         }
-        
+
         # Set environment variables, handling those with default values
         # cf. https://aquasecurity.github.io/trivy/latest/docs/configuration/#environment-variables
-        set_env_var_if_provided "TRIVY_INPUT" "${{ inputs.input }}" ""
-        set_env_var_if_provided "TRIVY_EXIT_CODE" "${{ inputs.exit-code }}" ""
-        set_env_var_if_provided "TRIVY_IGNORE_UNFIXED" "${{ inputs.ignore-unfixed }}" "false"
-        set_env_var_if_provided "TRIVY_PKG_TYPES" "${{ inputs.vuln-type }}" "os,library"
-        set_env_var_if_provided "TRIVY_SEVERITY" "${{ inputs.severity }}" "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL"
-        set_env_var_if_provided "TRIVY_FORMAT" "${{ inputs.format }}" "table"
-        set_env_var_if_provided "TRIVY_TEMPLATE" "${{ inputs.template }}" ""
-        set_env_var_if_provided "TRIVY_OUTPUT" "${{ inputs.output }}" ""
-        set_env_var_if_provided "TRIVY_SKIP_DIRS" "${{ inputs.skip-dirs }}" ""
-        set_env_var_if_provided "TRIVY_SKIP_FILES" "${{ inputs.skip-files }}" ""
-        set_env_var_if_provided "TRIVY_TIMEOUT" "${{ inputs.timeout }}" ""
-        set_env_var_if_provided "TRIVY_IGNORE_POLICY" "${{ inputs.ignore-policy }}" ""
-        set_env_var_if_provided "TRIVY_QUIET" "${{ inputs.hide-progress }}" ""
-        set_env_var_if_provided "TRIVY_LIST_ALL_PKGS" "${{ inputs.list-all-pkgs }}" "false"
-        set_env_var_if_provided "TRIVY_SCANNERS" "${{ inputs.scanners }}" ""
-        set_env_var_if_provided "TRIVY_CONFIG" "${{ inputs.trivy-config }}" ""
-        set_env_var_if_provided "TRIVY_TF_VARS" "${{ inputs.tf-vars }}" ""
-        set_env_var_if_provided "TRIVY_DOCKER_HOST" "${{ inputs.docker-host }}" ""
+        set_env_var_if_provided "TRIVY_INPUT" "$INPUT_INPUT" ""
+        set_env_var_if_provided "TRIVY_EXIT_CODE" "$INPUT_EXIT_CODE" ""
+        set_env_var_if_provided "TRIVY_IGNORE_UNFIXED" "$INPUT_IGNORE_UNFIXED" "false"
+        set_env_var_if_provided "TRIVY_PKG_TYPES" "$INPUT_VULN_TYPE" "os,library"
+        set_env_var_if_provided "TRIVY_SEVERITY" "$INPUT_SEVERITY" "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL"
+        set_env_var_if_provided "TRIVY_FORMAT" "$INPUT_FORMAT" "table"
+        set_env_var_if_provided "TRIVY_TEMPLATE" "$INPUT_TEMPLATE" ""
+        set_env_var_if_provided "TRIVY_OUTPUT" "$INPUT_OUTPUT" ""
+        set_env_var_if_provided "TRIVY_SKIP_DIRS" "$INPUT_SKIP_DIRS" ""
+        set_env_var_if_provided "TRIVY_SKIP_FILES" "$INPUT_SKIP_FILES" ""
+        set_env_var_if_provided "TRIVY_TIMEOUT" "$INPUT_TIMEOUT" ""
+        set_env_var_if_provided "TRIVY_IGNORE_POLICY" "$INPUT_IGNORE_POLICY" ""
+        set_env_var_if_provided "TRIVY_QUIET" "$INPUT_HIDE_PROGRESS" ""
+        set_env_var_if_provided "TRIVY_LIST_ALL_PKGS" "$INPUT_LIST_ALL_PKGS" "false"
+        set_env_var_if_provided "TRIVY_SCANNERS" "$INPUT_SCANNERS" ""
+        set_env_var_if_provided "TRIVY_CONFIG" "$INPUT_TRIVY_CONFIG" ""
+        set_env_var_if_provided "TRIVY_TF_VARS" "$INPUT_TF_VARS" ""
+        set_env_var_if_provided "TRIVY_DOCKER_HOST" "$INPUT_DOCKER_HOST" ""
 
     - name: Run Trivy
       shell: bash


### PR DESCRIPTION
## Summary
Add zizmor linter to detect security issues in GitHub Actions workflows

## Reasons
[zizmor](https://github.com/zizmorcore/zizmor) is a static analysis tool that finds common security issues in GitHub Actions, including:
- Template injection vulnerabilities
- Artifact poisoning
- Excessive permissions
- Unpinned actions