### PR TITLE
chore: bump default Trivy version to v0.69.2

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -98,7 +98,7 @@ inputs:
   version:
     description: 'Trivy version to use'
     required: false
-    default: 'v0.69.1'
+    default: 'v0.69.2'
   cache:
     description: 'Used to specify whether caching is needed. Set to false, if you would like to disable caching.'
     required: false


### PR DESCRIPTION
## Summary
Bumps the default Trivy version from `v0.69.1` to `v0.69.2`.

The `v0.69.1` release assets were deleted from the `aquasecurity/trivy` repository, causing `setup-trivy` to fail with exit code 1 when the binary cache is cold. `v0.69.2` releases are available and resolve the issue.

Fixes #512