### PR TITLE
chore: add top-level permissions: {} to all workflow files

### DIFF
--- a/.github/workflows/bump-trivy.yaml
+++ b/.github/workflows/bump-trivy.yaml
@@ -10,6 +10,8 @@ on:
 
 run-name: Bump trivy to v${{ inputs.trivy_version }}
 
+permissions: {}
+
 jobs:
   bump:
     runs-on: ubuntu-latest

--- a/.github/workflows/sync-trivy-checks.yaml
+++ b/.github/workflows/sync-trivy-checks.yaml
@@ -2,6 +2,9 @@ name: Sync Trivy Checks
 
 on:
   workflow_dispatch:
+
+permissions: {}
+
 env:
   IMAGE_NAME: ${{ github.repository_owner }}/trivy-checks-act
   REGISTRY: ghcr.io

--- a/.github/workflows/sync-trivy-db.yaml
+++ b/.github/workflows/sync-trivy-db.yaml
@@ -2,6 +2,9 @@ name: Sync Trivy DB
 
 on:
   workflow_dispatch:
+
+permissions: {}
+
 env:
   IMAGE_NAME: ${{ github.repository_owner }}/trivy-db-act
   REGISTRY: ghcr.io

--- a/.github/workflows/sync-trivy-java-db.yaml
+++ b/.github/workflows/sync-trivy-java-db.yaml
@@ -2,6 +2,9 @@ name: Sync Trivy Java DB
 
 on:
   workflow_dispatch:
+
+permissions: {}
+
 env:
   IMAGE_NAME: ${{ github.repository_owner }}/trivy-java-db-act
   REGISTRY: ghcr.io

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,6 +5,8 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions: {}
+
 env:
   TRIVY_VERSION: 0.69.3
   BATS_LIB_PATH: '/usr/lib/'


### PR DESCRIPTION
## Summary
- Add explicit top-level `permissions: {}` to all 5 GitHub Actions workflow files
- Restricts the default `GITHUB_TOKEN` permissions to none, enforcing least-privilege

## Motivation
Closes #499 — While each job already defines minimum required permissions (e.g. `contents: read`, `packages: write`), there is no top-level restriction. Without `permissions: {}` at the workflow level, any newly added job that omits a `permissions` block would inherit GitHub's default (read-write) token permissions, increasing the blast radius if a workflow is compromised.

## Changes
| Workflow | Change |
|----------|--------|
| `test.yaml` | Added `permissions: {}` |
| `bump-trivy.yaml` | Added `permissions: {}` |
| `sync-trivy-checks.yaml` | Added `permissions: {}` |
| `sync-trivy-db.yaml` | Added `permissions: {}` |
| `sync-trivy-java-db.yaml` | Added `permissions: {}` |

## References
- [GitHub: Using permissions in workflows](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token)
- [OpenSSF Scorecard: Token-Permissions check](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions)