### PR TITLE
Update setup-trivy action to version v0.2.6

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -126,7 +126,7 @@ runs:
       # "allowing select actions" feature can be used to whitelist the dependent action by a hash.
       # This is needed since some organizations have a policy to only allow pinned 3rd party actions to 
       # be used.
-      uses: aquasecurity/setup-trivy@e6c2c5e321ed9123bda567646e2f96565e34abe1 # equivalent to `v0.2.4`
+      uses: aquasecurity/setup-trivy@3fb12ec12f41e471780db15c232d5dd185dcb514 # equivalent to `v0.2.6`
       with:
         version: ${{ inputs.version }}
         cache: ${{ inputs.cache }}


### PR DESCRIPTION
Update setup-trivy to [0.2.6](https://github.com/aquasecurity/setup-trivy/releases/tag/v0.2.6) (as was 0.2.5) that pins to a specific commit of aquasecurity/trivy.
