### PR TITLE
chore(deps): Update actions/cache to v5.0.4 - fixes issue #528

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -139,7 +139,7 @@ runs:
 
     - name: Restore DB from cache
       if: ${{ inputs.cache == 'true' }}
-      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       with:
         path: ${{ inputs.cache-dir }}
         key: cache-trivy-${{ steps.date.outputs.date }}


### PR DESCRIPTION
latest version shows node20 deprecation warnings due to using an older version of actions/cache
the latest version uses node24 so just needs to bump
fixes issue #528