### PR TITLE
fix: use portable shebang in entrypoint.sh

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 # Allow overriding trivy binary via env


### PR DESCRIPTION
## Summary

Replace `#!/bin/bash` with `#!/usr/bin/env bash` in `entrypoint.sh`.

The hardcoded `/bin/bash` path causes `exit code 126` (bad interpreter) on NixOS-based self-hosted runners, where bash is installed under `/nix/store/` and `/bin/bash` does not exist.