### PR TITLE
chore(ci): update bump-trivy workflow

### DIFF
--- a/.github/workflows/bump-trivy.yaml
+++ b/.github/workflows/bump-trivy.yaml
@@ -12,7 +12,7 @@ run-name: Bump trivy to v${{ inputs.trivy_version }}
 
 jobs:
   bump:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-2404-2core
     permissions:
       contents: read
     steps:
@@ -50,7 +50,7 @@ jobs:
         id: create-pr
         uses: peter-evans/create-pull-request@4e1beaa7521e8b457b572c090b25bd3db56bf1c5 # v5
         with:
-          token: ${{ secrets.ORG_REPO_TOKEN }}
+          token: ${{ secrets.TRIVY_ACTION_DEPLOY_TOKEN }}
           title: "chore(deps): Update trivy to v${{ inputs.trivy_version }}"
           commit-message: "chore(deps): Update trivy to v${{ inputs.trivy_version }}"
           committer: github-actions[bot] <github-actions[bot]@users.noreply.github.com>


### PR DESCRIPTION
## Summary
- Replace `ubuntu-latest` runner with `ubuntu-2404-2core` in `bump-trivy.yaml`
- Replace `ORG_REPO_TOKEN` secret with `TRIVY_ACTION_DEPLOY_TOKEN`

## TODO
- [ ] Replace `peter-evans/create-pull-request` with a script using `gh` CLI to create PRs