### PR TITLE
ci: add dependabot config

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Add dependabot configuration for GH Actions with weekly updates and a 7-day cooldown.

```bash
❯ zizmor .github/dependabot.yaml
🌈 zizmor v1.23.1
 INFO audit: zizmor: 🌈 completed .github/dependabot.yaml
No findings to report. Good job!
```