### PR TITLE
chore: add zizmor config

### DIFF
--- a/zizmor.yaml
+++ b/zizmor.yaml
@@ -1,0 +1,5 @@
+rules:
+  # GitHub environments are not currently used, so secrets are accessed outside of them.
+  # See: https://docs.zizmor.sh/audits/#secrets-outside-env
+  secrets-outside-env:
+    disable: true


### PR DESCRIPTION
Add zizmor configuration to disable the `secrets-outside-env` rule.