### PR TITLE
feat: add support for posting scan results as PR comments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ BATS_ENV := BATS_LIB_PATH=$(BATS_LIB_PATH) \
 	TRIVY_CACHE_DIR=$(CACHE_DIR) \
 	TRIVY_DEBUG=true
 
-BATS_FLAGS := --timing --verbose-run test/test.bats
+BATS_FLAGS := --timing --verbose-run test/test.bats test/comment-on-pr.bats
 
 .PHONY: test
 test:

--- a/README.md
+++ b/README.md
@@ -875,7 +875,7 @@ jobs:
         run: docker build -t docker.io/my-organization/my-app:${{ github.sha }} .
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.33.1
+        uses: aquasecurity/trivy-action@0.35.0
         with:
           image-ref: 'docker.io/my-organization/my-app:${{ github.sha }}'
           severity: 'CRITICAL,HIGH'
@@ -883,16 +883,16 @@ jobs:
 ```
 
 **Notes:**
-- The workflow must have `pull-requests: write` permission. The action uses the built-in `GITHUB_TOKEN` automatically — no extra token configuration is needed.
-- On non-PR events (e.g., `push`), the comment step is skipped gracefully.
-- If the action is invoked multiple times in the same workflow (e.g., `image` scan + `fs` scan), each scan type gets its own comment. Re-running the workflow updates the existing comments instead of creating duplicates.
+- The workflow must have `pull-requests: write` permission. For same-repo pull requests, the built-in `GITHUB_TOKEN` is usually sufficient. For fork-based pull requests, comment posting depends on repository or organization Actions permission settings.
+- On non-PR events (e.g., `push`, `workflow_dispatch`), the comment step is skipped gracefully. The action also detects associated pull requests from `workflow_run` and `issue_comment` (on PRs) events.
+- Each unique scan (determined by scan type and target) gets its own comment. Re-running the workflow updates the existing comment instead of creating duplicates.
 - When combining `comment-on-pr` with `trivy-config`, set the `output` input explicitly so the action can read the scan results.
 
 #### Multiple scans with PR comments
 
 ```yaml
       - name: Trivy image scan
-        uses: aquasecurity/trivy-action@0.33.1
+        uses: aquasecurity/trivy-action@0.35.0
         with:
           scan-type: 'image'
           image-ref: 'docker.io/my-organization/my-app:${{ github.sha }}'
@@ -900,7 +900,7 @@ jobs:
           comment-on-pr: 'true'
 
       - name: Trivy filesystem scan
-        uses: aquasecurity/trivy-action@0.33.1
+        uses: aquasecurity/trivy-action@0.35.0
         with:
           scan-type: 'fs'
           scan-ref: '.'
@@ -908,7 +908,7 @@ jobs:
           comment-on-pr: 'true'
 ```
 
-Each scan type (`image`, `fs`) will produce a separate PR comment.
+Each unique combination of scan type and target produces a separate PR comment. Running the same scan type on different targets (e.g., two different images) also creates separate comments.
 
 ## Customizing
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
   * [Using Trivy to generate SBOM](#using-trivy-to-generate-sbom)
   * [Using Trivy to scan your private registry](#using-trivy-to-scan-your-private-registry)
   * [Using Trivy if you don't have code scanning enabled](#using-trivy-if-you-dont-have-code-scanning-enabled)
+  * [Posting scan results as PR comments](#posting-scan-results-as-pr-comments)
 * [Customizing](#customizing)
   * [inputs](#inputs)
   * [Environment variables](#environment-variables)
@@ -851,6 +852,64 @@ This step is especially useful for private repositories without [GitHub Advanced
     fi
 ```
 
+### Posting scan results as PR comments
+
+You can automatically post Trivy scan results as a comment on pull requests. This makes it easy to review vulnerabilities directly in the PR without navigating to the Actions tab.
+
+```yaml
+name: build
+on:
+  pull_request:
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: write  # Required for posting PR comments
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build an image from Dockerfile
+        run: docker build -t docker.io/my-organization/my-app:${{ github.sha }} .
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@0.33.1
+        with:
+          image-ref: 'docker.io/my-organization/my-app:${{ github.sha }}'
+          severity: 'CRITICAL,HIGH'
+          comment-on-pr: 'true'
+```
+
+**Notes:**
+- The workflow must have `pull-requests: write` permission. The action uses the built-in `GITHUB_TOKEN` automatically — no extra token configuration is needed.
+- On non-PR events (e.g., `push`), the comment step is skipped gracefully.
+- If the action is invoked multiple times in the same workflow (e.g., `image` scan + `fs` scan), each scan type gets its own comment. Re-running the workflow updates the existing comments instead of creating duplicates.
+- When combining `comment-on-pr` with `trivy-config`, set the `output` input explicitly so the action can read the scan results.
+
+#### Multiple scans with PR comments
+
+```yaml
+      - name: Trivy image scan
+        uses: aquasecurity/trivy-action@0.33.1
+        with:
+          scan-type: 'image'
+          image-ref: 'docker.io/my-organization/my-app:${{ github.sha }}'
+          severity: 'CRITICAL,HIGH'
+          comment-on-pr: 'true'
+
+      - name: Trivy filesystem scan
+        uses: aquasecurity/trivy-action@0.33.1
+        with:
+          scan-type: 'fs'
+          scan-ref: '.'
+          severity: 'CRITICAL,HIGH'
+          comment-on-pr: 'true'
+```
+
+Each scan type (`image`, `fs`) will produce a separate PR comment.
+
 ## Customizing
 
 Configuration priority:
@@ -894,6 +953,7 @@ Following inputs can be used as `step.with` keys:
 | `version`                    | String  | `v0.69.3`                          | Trivy version to use, e.g. `latest` or `v0.69.3`                                                                                                                 |
 | `skip-setup-trivy`           | Boolean | false                              | Skip calling the `setup-trivy` action to install `trivy`                                                                                                         |
 | `token-setup-trivy`          | Boolean |                                    | Overwrite `github.token` used by `setup-trivy` to checkout the `trivy` repository                                                                                |
+| `comment-on-pr`              | Boolean | false                              | Post scan results as a PR comment. Requires `pull-requests: write` permission                                                                                    |
 
 ### Environment variables
 You can use [Trivy environment variables][trivy-env] to set the necessary options (including flags that are not supported by [Inputs](#inputs), such as `--secret-config`).

--- a/action.yaml
+++ b/action.yaml
@@ -116,6 +116,10 @@ inputs:
     ## ${{ github.token }} is default value for actions/checkout
     ## cf. https://github.com/actions/checkout/blob/eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871/action.yml#L24
     default: ${{ github.token }}
+  comment-on-pr:
+    description: 'Post scan results as a PR comment. Requires pull-requests: write permission.'
+    required: false
+    default: 'false'
 
 runs:
   using: 'composite'
@@ -243,6 +247,9 @@ runs:
         INPUT_TRIVYIGNORES: ${{ inputs.trivyignores }}
         INPUT_GITHUB_PAT: ${{ inputs.github-pat }}
         INPUT_LIMIT_SEVERITIES_FOR_SARIF: ${{ inputs.limit-severities-for-sarif }}
+        INPUT_COMMENT_ON_PR: ${{ inputs.comment-on-pr }}
+        INPUT_GITHUB_TOKEN: ${{ github.token }}
+        GITHUB_API_URL: ${{ github.api_url }}
 
         # For Trivy
         TRIVY_CACHE_DIR: ${{ inputs.cache-dir }} # Always set

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,8 +4,8 @@ set -euo pipefail
 # Allow overriding trivy binary via env
 TRIVY_CMD="${TRIVY_CMD:-trivy}"
 
-# Read TRIVY_* envs from file, previously they were written to the GITHUB_ENV file but GitHub Actions automatically 
-# injects those into subsequent job steps which means inputs from one trivy-action invocation were leaking over to 
+# Read TRIVY_* envs from file, previously they were written to the GITHUB_ENV file but GitHub Actions automatically
+# injects those into subsequent job steps which means inputs from one trivy-action invocation were leaking over to
 # any subsequent invocation which led to unexpected/undesireable behaviour from a user perspective
 # See #422 for more context around this
 if [ -f ./trivy_envs.txt ]; then
@@ -82,11 +82,170 @@ if [ "${TRIVY_FORMAT:-}" = "sarif" ]; then
   fi
 fi
 
+# If comment-on-pr is enabled and no output file is set, use a temp file
+# so we can read scan results for the PR comment.
+# Note: if output is configured via trivy.yaml (not via the action input), TRIVY_OUTPUT
+# will be empty here and a temp file is used. Set the 'output' action input explicitly
+# when combining comment-on-pr with trivy-config.
+trivy_comment_file=""
+original_trivy_output="${TRIVY_OUTPUT:-}"
+if [ "${INPUT_COMMENT_ON_PR:-false}" = "true" ]; then
+  if [ -z "${TRIVY_OUTPUT:-}" ]; then
+    trivy_comment_file=$(mktemp "${TMPDIR:-/tmp}/trivy-results-XXXXXX")
+    export TRIVY_OUTPUT="$trivy_comment_file"
+  else
+    trivy_comment_file="${TRIVY_OUTPUT}"
+  fi
+fi
+
 # Run Trivy
 cmd=("$TRIVY_CMD" "$scanType" "$scanRef")
 echo "Running Trivy with options: ${cmd[*]}"
-"${cmd[@]}"
-returnCode=$?
+
+if [ "${INPUT_COMMENT_ON_PR:-false}" = "true" ]; then
+  # Capture exit code so we can still post the comment on failure
+  "${cmd[@]}" && returnCode=0 || returnCode=$?
+else
+  "${cmd[@]}"
+  returnCode=$?
+fi
+
+# If we redirected output to a temp file, print results to stdout
+# so they still appear in the action logs
+if [ -n "$trivy_comment_file" ] && [ -z "$original_trivy_output" ] && [ -f "$trivy_comment_file" ]; then
+  cat "$trivy_comment_file"
+fi
+
+# Post PR comment
+if [ "${INPUT_COMMENT_ON_PR:-false}" = "true" ]; then
+  if [ -z "${INPUT_GITHUB_TOKEN:-}" ]; then
+    echo "WARNING: comment-on-pr is enabled but GITHUB_TOKEN is not available. Skipping PR comment." >&2
+  elif [ -z "${GITHUB_EVENT_PATH:-}" ]; then
+    echo "WARNING: GITHUB_EVENT_PATH is not set. Skipping PR comment." >&2
+  else
+    # Extract PR number from the event payload across all trigger types:
+    #   pull_request / pull_request_target  → .pull_request.number
+    #   workflow_run                        → .workflow_run.pull_requests[0].number
+    #   issue_comment (on a PR only)        → .issue.number (guarded by .issue.pull_request)
+    pr_number=$(jq -r '
+      .pull_request.number //
+      .workflow_run.pull_requests[0].number //
+      (select(.issue.pull_request) | .issue.number) //
+      empty
+    ' "$GITHUB_EVENT_PATH" 2>/dev/null || true)
+
+    if [ -z "$pr_number" ]; then
+      echo "INFO: No associated pull request found. Skipping PR comment."
+    else
+      echo "Posting scan results as PR comment..."
+
+      # Read scan results
+      scan_results=""
+      if [ -n "$trivy_comment_file" ] && [ -f "$trivy_comment_file" ]; then
+        scan_results=$(cat "$trivy_comment_file")
+      fi
+
+      # If scan failed, always show the failure regardless of file contents
+      # (the file may contain stale data from a previous scan in the same job)
+      if [ "$returnCode" -ne 0 ] && [ -z "$scan_results" ]; then
+        scan_results="Trivy scan failed with exit code ${returnCode}. Check the action logs for details."
+      elif [ "$returnCode" -ne 0 ]; then
+        scan_results="Trivy scan failed with exit code ${returnCode}.
+
+${scan_results}"
+      elif [ -z "$scan_results" ]; then
+        scan_results="No vulnerabilities found."
+      fi
+
+      # Truncate if too long (GitHub comment limit is 65536 chars, leave room for markdown wrapper)
+      max_len=60000
+      if [ "${#scan_results}" -gt "$max_len" ]; then
+        scan_results="${scan_results:0:$max_len}
+
+... (truncated, full results available in the action logs)"
+      fi
+
+      # Determine code fence language based on format
+      fence_lang=""
+      case "${TRIVY_FORMAT:-table}" in
+        json|sarif|github) fence_lang="json" ;;
+      esac
+
+      # Include scan type in marker so multiple scans on the same PR
+      # each get their own comment instead of overwriting each other
+      comment_marker="<!-- trivy-action-comment:${scanType} -->"
+
+      # Show scan status in the header
+      if [ "$returnCode" -ne 0 ]; then
+        status_badge="**Status:** FAILED (exit code ${returnCode})"
+      else
+        status_badge="**Status:** Completed"
+      fi
+
+      comment_body="${comment_marker}
+## Trivy Scan Results
+
+**Scan type:** \`${scanType}\` | **Target:** \`${scanRef}\` | ${status_badge}
+
+<details>
+<summary>Click to expand scan results</summary>
+
+\`\`\`${fence_lang}
+${scan_results}
+\`\`\`
+
+</details>"
+
+      # Escape for JSON payload
+      comment_json=$(jq -n --arg body "$comment_body" '{"body": $body}')
+
+      api_base="${GITHUB_API_URL:-https://api.github.com}"
+      api_url="${api_base}/repos/${GITHUB_REPOSITORY}/issues/${pr_number}/comments"
+
+      # Post or update PR comment
+      # Disable exit-on-error so API failures don't abort a successful scan
+      set +e
+
+      # Check for existing trivy comment with the same scan type to update (avoids duplicate comments)
+      existing_comment_id=$(curl -s \
+        -H "Authorization: token ${INPUT_GITHUB_TOKEN}" \
+        -H "Accept: application/vnd.github+json" \
+        "${api_url}?per_page=100" \
+        | jq --arg marker "$comment_marker" \
+          '[.[] | select(.body | contains($marker))] | first | .id // empty' \
+        2>/dev/null)
+
+      if [ -n "$existing_comment_id" ]; then
+        # Update existing comment
+        http_code=$(curl -s -o /dev/null -w '%{http_code}' -X PATCH \
+          -H "Authorization: token ${INPUT_GITHUB_TOKEN}" \
+          -H "Accept: application/vnd.github+json" \
+          "${api_base}/repos/${GITHUB_REPOSITORY}/issues/comments/${existing_comment_id}" \
+          -d "$comment_json")
+        if [ "$http_code" -ge 200 ] && [ "$http_code" -lt 300 ]; then
+          echo "Updated existing PR comment (comment ID: ${existing_comment_id})."
+        else
+          echo "WARNING: Failed to update PR comment (HTTP ${http_code}). Check token permissions (pull-requests: write)." >&2
+        fi
+      else
+        # Create new comment
+        http_code=$(curl -s -o /dev/null -w '%{http_code}' -X POST \
+          -H "Authorization: token ${INPUT_GITHUB_TOKEN}" \
+          -H "Accept: application/vnd.github+json" \
+          "${api_url}" \
+          -d "$comment_json")
+        if [ "$http_code" -ge 200 ] && [ "$http_code" -lt 300 ]; then
+          echo "Created new PR comment."
+        else
+          echo "WARNING: Failed to create PR comment (HTTP ${http_code}). Check token permissions (pull-requests: write)." >&2
+        fi
+      fi
+
+      set -e
+    fi
+  fi
+
+fi
 
 if [ "${TRIVY_FORMAT:-}" = "github" ]; then
   if [ -n "${INPUT_GITHUB_PAT:-}" ]; then
@@ -96,6 +255,11 @@ if [ "${TRIVY_FORMAT:-}" = "github" ]; then
   else
     printf "\n Failing GitHub Dependency Snapshot. Missing github-pat" >&2
   fi
+fi
+
+# Cleanup temp file if we created one for PR commenting
+if [ -n "${trivy_comment_file:-}" ] && [ -z "$original_trivy_output" ]; then
+  rm -f "$trivy_comment_file"
 fi
 
 exit $returnCode

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -171,9 +171,12 @@ ${scan_results}"
         json|sarif|github) fence_lang="json" ;;
       esac
 
-      # Include scan type in marker so multiple scans on the same PR
-      # each get their own comment instead of overwriting each other
-      comment_marker="<!-- trivy-action-comment:${scanType} -->"
+      # Include scan type and target hash in marker so each unique scan
+      # gets its own comment (e.g. two different image scans won't overwrite each other)
+      # Also include TRIVY_INPUT for tarball scans where scanRef stays at default
+      marker_input="${TRIVY_INPUT:-}"
+      marker_hash=$(printf '%s:%s:%s' "$scanType" "$scanRef" "$marker_input" | cksum | cut -d' ' -f1)
+      comment_marker="<!-- trivy-action-comment:${scanType}:${marker_hash} -->"
 
       # Show scan status in the header
       if [ "$returnCode" -ne 0 ]; then
@@ -206,14 +209,27 @@ ${scan_results}
       # Disable exit-on-error so API failures don't abort a successful scan
       set +e
 
-      # Check for existing trivy comment with the same scan type to update (avoids duplicate comments)
-      existing_comment_id=$(curl -s \
-        -H "Authorization: token ${INPUT_GITHUB_TOKEN}" \
-        -H "Accept: application/vnd.github+json" \
-        "${api_url}?per_page=100" \
-        | jq --arg marker "$comment_marker" \
-          '[.[] | select(.body | contains($marker))] | first | .id // empty' \
-        2>/dev/null)
+      # Search for existing trivy comment to update (avoids duplicate comments)
+      # Paginate to handle PRs with many comments
+      existing_comment_id=""
+      page=1
+      while [ -z "$existing_comment_id" ] && [ "$page" -le 5 ]; do
+        page_comments=$(curl -s \
+          -H "Authorization: token ${INPUT_GITHUB_TOKEN}" \
+          -H "Accept: application/vnd.github+json" \
+          "${api_url}?per_page=100&page=${page}")
+
+        # Stop if page is empty
+        if [ "$(echo "$page_comments" | jq 'length' 2>/dev/null)" = "0" ]; then
+          break
+        fi
+
+        existing_comment_id=$(echo "$page_comments" \
+          | jq --arg marker "$comment_marker" \
+            '[.[] | select(.body | contains($marker))] | first | .id // empty' \
+          2>/dev/null)
+        page=$((page + 1))
+      done
 
       if [ -n "$existing_comment_id" ]; then
         # Update existing comment

--- a/test/comment-on-pr.bats
+++ b/test/comment-on-pr.bats
@@ -1,0 +1,211 @@
+#!/usr/bin/env bats
+
+bats_load_library bats-support
+bats_load_library bats-assert
+
+setup_file() {
+  setup_trivy_env
+  # Download DB for fs scans
+  "${TRIVY_CMD:-trivy}" fs --no-progress --download-db-only 1>&3 2>&3
+}
+
+setup() {
+  export TRIVY_SKIP_DB_UPDATE=true
+  export TRIVY_SKIP_JAVA_DB_UPDATE=true
+}
+
+teardown() {
+  reset_envs
+}
+
+setup_trivy_env() {
+  export TRIVY_DB_REPOSITORY="ghcr.io/aquasecurity/trivy-db@sha256:7f8b879d4c23469b09c874b18d64a7eedea95f0ce08ea1862a783dc8d799be6f"
+  export TRIVY_JAVA_DB_REPOSITORY="ghcr.io/aquasecurity/trivy-java-db@sha256:f60faf3353edb6556f676c83c8b26d8a60398feab31ab2ec591537707a7354ba"
+  export TRIVY_CHECKS_BUNDLE_REPOSITORY="ghcr.io/aquasecurity/trivy-checks@sha256:b63166ca02aa09e30a5127320384d7bd0d2760dc19bab3ab7041a6070114ba45" # v2.2.0
+
+  export TRIVY_LIST_ALL_PKGS=false
+  export TRIVY_DISABLE_VEX_NOTICE=true
+  export TRIVY_SKIP_VERSION_CHECK=true
+  export TRIVY_DISABLE_TELEMETRY=true
+}
+
+reset_envs() {
+  local var
+  for var in $(env | grep '^TRIVY_\|^INPUT_\|^GITHUB_' | cut -d= -f1); do
+    unset "$var"
+  done
+  rm -f trivy_envs.txt
+  # Re-set trivy env for next test
+  setup_trivy_env
+}
+
+setup_mock_curl() {
+  local mock_dir="$BATS_TEST_TMPDIR/mock-bin"
+  mkdir -p "$mock_dir"
+  cat > "$mock_dir/curl" <<'MOCK_CURL'
+#!/usr/bin/env bash
+# Return empty array for comment listing (GET with per_page)
+if [[ "$*" == *"per_page"* ]]; then
+  echo "[]"
+  exit 0
+fi
+# Return 201 for POST/PATCH (when -w '%{http_code}' is used)
+if [[ "$*" == *"-w"* ]]; then
+  echo "201"
+  exit 0
+fi
+exit 0
+MOCK_CURL
+  chmod +x "$mock_dir/curl"
+  export PATH="$mock_dir:$PATH"
+}
+
+@test "comment-on-pr skips on non-PR event" {
+  local event_file="$BATS_TEST_TMPDIR/push-event.json"
+  echo '{"ref": "refs/heads/main"}' > "$event_file"
+
+  export TRIVY_OUTPUT="$BATS_TEST_TMPDIR/output.test"
+  export INPUT_COMMENT_ON_PR=true \
+         INPUT_GITHUB_TOKEN=fake-token \
+         GITHUB_EVENT_PATH="$event_file" \
+         INPUT_SCAN_TYPE=fs \
+         INPUT_SCAN_REF=./test/data/fs-scan
+
+  run ./entrypoint.sh
+  assert_success
+  assert_output --partial "No associated pull request found. Skipping PR comment."
+}
+
+@test "comment-on-pr skips without GITHUB_TOKEN" {
+  local event_file="$BATS_TEST_TMPDIR/pr-event.json"
+  echo '{"pull_request": {"number": 1}}' > "$event_file"
+
+  export TRIVY_OUTPUT="$BATS_TEST_TMPDIR/output.test"
+  export INPUT_COMMENT_ON_PR=true \
+         INPUT_GITHUB_TOKEN="" \
+         GITHUB_EVENT_PATH="$event_file" \
+         INPUT_SCAN_TYPE=fs \
+         INPUT_SCAN_REF=./test/data/fs-scan
+
+  run ./entrypoint.sh
+  assert_success
+  assert_output --partial "GITHUB_TOKEN is not available. Skipping PR comment."
+}
+
+@test "comment-on-pr posts comment on pull_request event" {
+  setup_mock_curl
+
+  local event_file="$BATS_TEST_TMPDIR/pr-event.json"
+  echo '{"pull_request": {"number": 42}}' > "$event_file"
+
+  export TRIVY_OUTPUT="$BATS_TEST_TMPDIR/output.test"
+  export INPUT_COMMENT_ON_PR=true \
+         INPUT_GITHUB_TOKEN=fake-token \
+         GITHUB_EVENT_PATH="$event_file" \
+         GITHUB_REPOSITORY=test/repo \
+         GITHUB_API_URL=https://api.github.com \
+         INPUT_SCAN_TYPE=fs \
+         INPUT_SCAN_REF=./test/data/fs-scan
+
+  run ./entrypoint.sh
+  assert_success
+  assert_output --partial "Created new PR comment."
+}
+
+@test "comment-on-pr extracts PR number from workflow_run event" {
+  setup_mock_curl
+
+  local event_file="$BATS_TEST_TMPDIR/workflow-run-event.json"
+  echo '{"workflow_run": {"pull_requests": [{"number": 99}]}}' > "$event_file"
+
+  export TRIVY_OUTPUT="$BATS_TEST_TMPDIR/output.test"
+  export INPUT_COMMENT_ON_PR=true \
+         INPUT_GITHUB_TOKEN=fake-token \
+         GITHUB_EVENT_PATH="$event_file" \
+         GITHUB_REPOSITORY=test/repo \
+         GITHUB_API_URL=https://api.github.com \
+         INPUT_SCAN_TYPE=fs \
+         INPUT_SCAN_REF=./test/data/fs-scan
+
+  run ./entrypoint.sh
+  assert_success
+  assert_output --partial "Created new PR comment."
+}
+
+@test "comment-on-pr ignores plain issue events" {
+  local event_file="$BATS_TEST_TMPDIR/issue-event.json"
+  echo '{"issue": {"number": 10}}' > "$event_file"
+
+  export TRIVY_OUTPUT="$BATS_TEST_TMPDIR/output.test"
+  export INPUT_COMMENT_ON_PR=true \
+         INPUT_GITHUB_TOKEN=fake-token \
+         GITHUB_EVENT_PATH="$event_file" \
+         INPUT_SCAN_TYPE=fs \
+         INPUT_SCAN_REF=./test/data/fs-scan
+
+  run ./entrypoint.sh
+  assert_success
+  assert_output --partial "No associated pull request found. Skipping PR comment."
+}
+
+@test "comment-on-pr works for issue_comment on a PR" {
+  setup_mock_curl
+
+  local event_file="$BATS_TEST_TMPDIR/issue-comment-pr-event.json"
+  echo '{"issue": {"number": 15, "pull_request": {"url": "https://api.github.com/repos/test/repo/pulls/15"}}}' > "$event_file"
+
+  export TRIVY_OUTPUT="$BATS_TEST_TMPDIR/output.test"
+  export INPUT_COMMENT_ON_PR=true \
+         INPUT_GITHUB_TOKEN=fake-token \
+         GITHUB_EVENT_PATH="$event_file" \
+         GITHUB_REPOSITORY=test/repo \
+         GITHUB_API_URL=https://api.github.com \
+         INPUT_SCAN_TYPE=fs \
+         INPUT_SCAN_REF=./test/data/fs-scan
+
+  run ./entrypoint.sh
+  assert_success
+  assert_output --partial "Created new PR comment."
+}
+
+@test "comment-on-pr creates temp output and still prints to stdout" {
+  setup_mock_curl
+
+  local event_file="$BATS_TEST_TMPDIR/pr-event.json"
+  echo '{"pull_request": {"number": 1}}' > "$event_file"
+
+  # No TRIVY_OUTPUT — script should create a temp file and still print to stdout
+  export INPUT_COMMENT_ON_PR=true \
+         INPUT_GITHUB_TOKEN=fake-token \
+         GITHUB_EVENT_PATH="$event_file" \
+         GITHUB_REPOSITORY=test/repo \
+         GITHUB_API_URL=https://api.github.com \
+         INPUT_SCAN_TYPE=fs \
+         INPUT_SCAN_REF=./test/data/fs-scan
+
+  run ./entrypoint.sh
+  assert_success
+  assert_output --partial "Running Trivy with options:"
+  assert_output --partial "Created new PR comment."
+}
+
+@test "comment-on-pr still posts comment when scan fails" {
+  setup_mock_curl
+
+  local event_file="$BATS_TEST_TMPDIR/pr-event.json"
+  echo '{"pull_request": {"number": 1}}' > "$event_file"
+
+  export TRIVY_OUTPUT="$BATS_TEST_TMPDIR/output.test"
+  export INPUT_COMMENT_ON_PR=true \
+         INPUT_GITHUB_TOKEN=fake-token \
+         GITHUB_EVENT_PATH="$event_file" \
+         GITHUB_REPOSITORY=test/repo \
+         GITHUB_API_URL=https://api.github.com \
+         INPUT_SCAN_TYPE=image \
+         INPUT_SCAN_REF=no-such-image:latest
+
+  run ./entrypoint.sh
+  # Scan fails but comment should still be posted (not abort)
+  assert_output --partial "Posting scan results as PR comment..."
+  assert_output --partial "Created new PR comment."
+}


### PR DESCRIPTION
## Summary

This PR adds an optional `comment-on-pr` input to `trivy-action` so scan results can be posted directly as comments on pull requests.

## Motivation

For repositories that do not use GitHub code scanning / GitHub Advanced Security, scan results are usually reviewed in the Actions logs or workflow summary.

Posting the results directly on the pull request makes security feedback easier to review during code review and keeps the results closer to the change being reviewed.

## Changes

- add a new optional `comment-on-pr` input in `action.yaml`
- capture scan output when needed so it can be reused for PR comments
- create or update a PR comment with the scan results when the workflow is associated with a pull request
- skip PR commenting gracefully when no associated PR is found
- preserve scan output in the job logs when a temporary output file is used
- document the new input and usage examples in `README.md`

## Notes

- `comment-on-pr` is opt-in and defaults to `false`
- `pull-requests: write` permission is required to post PR comments
- when `comment-on-pr` is used together with `trivy-config`, `output` should be set explicitly so the action can read the scan results
- existing comments are updated per scan type to avoid creating duplicates on re-runs

## Validation

- [x] `make test`
- [x] verified comment creation on a `pull_request` workflow
- [x] verified an existing comment is updated on re-run
- [x] verified non-PR events skip commenting without failing the scan
- [x] verified scan failures still return the original exit code

## Test image

<img width="931" height="863" alt="스크린샷 2026-04-20 오후 7 49 50" src="https://github.com/user-attachments/assets/d96a583b-2f32-4240-825b-0ecc44933c20" />
<img width="1888" height="670" alt="스크린샷 2026-04-20 오후 7 50 11" src="https://github.com/user-attachments/assets/4e68418f-67e6-4250-b4b4-ba9b4e8cd035" />

