### PR TITLE
chore: use GitHub Actions as git commit author in bump-trivy workflow

### DIFF
--- a/.github/workflows/bump-trivy.yaml
+++ b/.github/workflows/bump-trivy.yaml
@@ -50,8 +50,8 @@ jobs:
           BASE_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
           gh auth setup-git
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "GitHub Actions"
+          git config user.email "actions@github.com"
           BRANCH="bump-trivy-${TRIVY_VERSION}"
           git checkout -b "${BRANCH}"
           git add action.yaml README.md test/


### PR DESCRIPTION
This PR updates the git commit author in the bump-trivy workflow to use the standard GitHub Actions bot identity.

Tested via:
```
GIT_AUTHOR_NAME="GitHub Actions" \
GIT_AUTHOR_EMAIL="actions@github.com" \
GIT_COMMITTER_NAME="GitHub Actions" \
GIT_COMMITTER_EMAIL="actions@github.com" \
git commit --amend --no-gpg-sign --reset-author --no-edit
```