### PR TITLE
ci: migrate from PAT to GitHub App token

### DIFF
--- a/.github/workflows/bump-trivy.yaml
+++ b/.github/workflows/bump-trivy.yaml
@@ -15,7 +15,6 @@ permissions: {}
 jobs:
   bump:
     runs-on: ubuntu-2404-2core
-    permissions: {}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/bump-trivy.yaml
+++ b/.github/workflows/bump-trivy.yaml
@@ -10,11 +10,12 @@ on:
 
 run-name: Bump trivy to v${{ inputs.trivy_version }}
 
+permissions: {}
+
 jobs:
   bump:
     runs-on: ubuntu-2404-2core
-    permissions:
-      contents: read # for actions/checkout
+    permissions: {}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -42,9 +43,19 @@ jobs:
           BATS_LIB_PATH: ${{ steps.setup-bats.outputs.lib-path }}
         run: make test
 
+      # Use a GitHub App token because GITHUB_TOKEN does not trigger CI on PRs created by workflows
+      - name: Generate token
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          client-id: ${{ secrets.REPO_TRIVY_ACTION_WRITE_GH_APP_CLIENT_ID }}
+          private-key: ${{ secrets.REPO_TRIVY_ACTION_WRITE_GH_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+
       - name: Create PR
         env:
-          GH_TOKEN: ${{ secrets.TRIVY_ACTION_DEPLOY_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           TRIVY_VERSION: ${{ inputs.trivy_version }}
           REPO: ${{ github.repository }}
           BASE_BRANCH: ${{ github.event.repository.default_branch }}


### PR DESCRIPTION
This PR updates the `bump-trivy.yaml` workflow to stop using a long-lived PAT and instead generate a short-lived GitHub App installation token.

How I tested:
- Created an GitHub App with the same permissions - `contents: write`
- Triggered the workflow manually - https://github.com/nikpivkin/trivy-action/actions/runs/25744280413/job/75603067901