### PR TITLE
docs: pin README examples to commit SHA instead of mutable version tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@
 
 ![](docs/images/trivy-action.png)
 
+> **Security Notice:** Always pin this action to a full 40-character commit SHA, not a version tag.
+> Version tags (e.g. `@v0.36.0`, `@master`) are mutable — any actor with write access to this repo can
+> silently redirect them to malicious code via a force-push, without your workflow YAML ever changing.
+> Use `aquasecurity/trivy-action@<sha> # vX.Y.Z` to pin immutably while keeping the version readable.
+> Run [`pinact run`](https://github.com/suzuki-shunsuke/pinact) to migrate all workflows in your repo automatically.
+
 ## Table of Contents
 
 * [Usage](#usage)
@@ -50,7 +56,7 @@ jobs:
       - name: Build an image from Dockerfile
         run: docker build -t docker.io/my-organization/my-app:${{ github.sha }} .
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8  # v0.36.0
         with:
           image-ref: 'docker.io/my-organization/my-app:${{ github.sha }}'
           format: 'table'
@@ -78,7 +84,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Run Trivy vulnerability scanner in fs mode
-      uses: aquasecurity/trivy-action@v0.36.0
+      uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8  # v0.36.0
       with:
         scan-type: 'fs'
         scan-ref: '.'
@@ -119,7 +125,7 @@ If you want to disable caching, set the `cache` input to `false`, but we recomme
 
 ```yaml
     - name: Run Trivy scanner without cache
-      uses: aquasecurity/trivy-action@v0.36.0
+      uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8  # v0.36.0
       with:
         scan-type: 'fs'
         scan-ref: '.'
@@ -180,7 +186,7 @@ When running a scan, set the environment variables `TRIVY_SKIP_DB_UPDATE` and `T
 
 ```yaml
     - name: Run Trivy scanner without downloading DBs
-      uses: aquasecurity/trivy-action@v0.36.0
+      uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8  # v0.36.0
       with:
         scan-type: 'image'
         scan-ref: 'myimage'
@@ -218,7 +224,7 @@ jobs:
         version: v0.70.0
 
     - name: Run Trivy vulnerability scanner in repo mode
-      uses: aquasecurity/trivy-action@master
+      uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8  # v0.36.0
       with:
         scan-type: 'fs'
         ignore-unfixed: true
@@ -252,7 +258,7 @@ jobs:
 
       # The first call to the action will invoke setup-trivy and install trivy
       - name: Generate Trivy Vulnerability Report
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8  # v0.36.0
         with:
           scan-type: "fs"
           output: trivy-report.json
@@ -268,7 +274,7 @@ jobs:
           retention-days: 30
 
       - name: Fail build on High/Criticial Vulnerabilities
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8  # v0.36.0
         with:
           scan-type: "fs"
           format: table
@@ -287,7 +293,7 @@ Therefore, you can't install `Trivy` using the `setup-trivy` action.
 To fix this problem, you need to overwrite the token for `setup-trivy` using `token-setup-trivy` input:
 ```yaml
     - name: Run Trivy scanner without cache
-      uses: aquasecurity/trivy-action@v0.36.0
+      uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8  # v0.36.0
       with:
         scan-type: 'fs'
         scan-ref: '.'
@@ -318,7 +324,7 @@ jobs:
         docker save -o vuln-image.tar <your-docker-image>
 
     - name: Run Trivy vulnerability scanner in tarball mode
-      uses: aquasecurity/trivy-action@v0.36.0
+      uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8  # v0.36.0
       with:
         input: /github/workspace/vuln-image.tar
         severity: 'CRITICAL,HIGH'
@@ -345,7 +351,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8  # v0.36.0
         with:
           scan-type: "fs"
           scan-ref: .
@@ -374,7 +380,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8  # v0.36.0
         with:
           scan-type: "fs"
           scan-ref: .
@@ -407,7 +413,7 @@ jobs:
           docker build -t docker.io/my-organization/my-app:${{ github.sha }} .
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8  # v0.36.0
         with:
           image-ref: 'docker.io/my-organization/my-app:${{ github.sha }}'
           format: 'sarif'
@@ -445,7 +451,7 @@ jobs:
           docker build -t docker.io/my-organization/my-app:${{ github.sha }} .
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8  # v0.36.0
         with:
           image-ref: 'docker.io/my-organization/my-app:${{ github.sha }}'
           format: 'sarif'
@@ -483,7 +489,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Trivy vulnerability scanner in repo mode
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8  # v0.36.0
         with:
           scan-type: 'fs'
           ignore-unfixed: true
@@ -520,7 +526,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Trivy vulnerability scanner with rootfs command
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8  # v0.36.0
         with:
           scan-type: 'rootfs'
           scan-ref: 'rootfs-example-binary'
@@ -560,7 +566,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Trivy vulnerability scanner in IaC mode
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8  # v0.36.0
         with:
           scan-type: 'config'
           hide-progress: true
@@ -617,7 +623,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Trivy in GitHub SBOM mode and submit results to Dependency Graph
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8  # v0.36.0
         with:
           scan-type: 'fs'
           format: 'github'
@@ -647,7 +653,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Scan image in a private registry
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8  # v0.36.0
         with:
           image-ref: "private_image_registry/image_name:image_tag"
           scan-type: image
@@ -693,7 +699,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8  # v0.36.0
         with:
           image-ref: 'docker.io/my-organization/my-app:${{ github.sha }}'
           format: 'sarif'
@@ -732,7 +738,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8  # v0.36.0
         with:
           image-ref: 'aws_account_id.dkr.ecr.region.amazonaws.com/imageName:${{ github.sha }}'
           format: 'sarif'
@@ -771,7 +777,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8  # v0.36.0
         with:
           image-ref: 'docker.io/my-organization/my-app:${{ github.sha }}'
           format: 'sarif'
@@ -807,7 +813,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8  # v0.36.0
         with:
           image-ref: 'docker.io/my-organization/my-app:${{ github.sha }}'
           format: 'sarif'
@@ -830,7 +836,7 @@ This step is especially useful for private repositories without [GitHub Advanced
 
 ```yaml
 - name: Run Trivy scanner
-  uses: aquasecurity/trivy-action@v0.36.0
+  uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8  # v0.36.0
   with:
     scan-type: config
     hide-progress: true


### PR DESCRIPTION
## Summary

All `uses:` references in README examples currently point to mutable refs —
either `@v0.36.0` or `@master`. Mutable version tags can be silently redirected
by a force-push to any commit, including malicious code, without the workflow
YAML ever changing. This is not a theoretical concern: the March 2026 Trivy
supply chain attack (GHSA-69fq-xp46-6x23) exploited exactly this vector — 76 of
77 `trivy-action` version tags were force-pushed to a credential-stealing binary
during a 12-hour window. The official incident advisory explicitly recommends
pinning to full commit SHAs.

The README is the first place new users copy workflow snippets from. Showing
`@v0.36.0` teaches the exact pattern that enables this attack class.

## Changes

- Replaced all 23 mutable `uses: aquasecurity/trivy-action@<tag>` refs in README
  examples with the immutable commit SHA for `v0.36.0`:
  `a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8`
- SHA verified via `git ls-remote https://github.com/aquasecurity/trivy-action.git refs/tags/v0.36.0`
- Kept a trailing `# v0.36.0` comment on each line for human readability
- Added a Security Notice callout at the top of the README explaining the risk
  and linking to [`pinact`](https://github.com/suzuki-shunsuke/pinact) for
  automated migration of existing workflows

## No behavior change

This is a pure documentation update. No action logic, inputs, or outputs are
modified. The SHA pinned is the same release that was previously referenced by
`@v0.36.0`.

## Verification

```bash
git ls-remote https://github.com/aquasecurity/trivy-action.git refs/tags/v0.36.0
# a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8	refs/tags/v0.36.0