### PR TITLE
ci: fix zizmor github-app and unpinned-tools issues

### DIFF
--- a/.github/workflows/bump-trivy.yaml
+++ b/.github/workflows/bump-trivy.yaml
@@ -51,6 +51,8 @@ jobs:
           private-key: ${{ secrets.REPO_TRIVY_ACTION_WRITE_GH_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: ${{ github.event.repository.name }}
+          permission-contents: write
+          permission-pull-requests: write
 
       - name: Create PR
         env:

--- a/action.yaml
+++ b/action.yaml
@@ -128,7 +128,7 @@ runs:
       # be used.
       uses: aquasecurity/setup-trivy@3fb12ec12f41e471780db15c232d5dd185dcb514 # v0.2.6
       with:
-        # false positive: inputs.version has a pinned default value, so it's never unpinned
+        # version is pinned by default; using a floating tag like `latest` is the caller's responsibility
         version: ${{ inputs.version }} # zizmor: ignore[unpinned-tools]
         cache: ${{ inputs.cache }}
         token: ${{ inputs.token-setup-trivy }}

--- a/action.yaml
+++ b/action.yaml
@@ -128,7 +128,8 @@ runs:
       # be used.
       uses: aquasecurity/setup-trivy@3fb12ec12f41e471780db15c232d5dd185dcb514 # v0.2.6
       with:
-        version: ${{ inputs.version }}
+        # false positive: inputs.version has a pinned default value, so it's never unpinned
+        version: ${{ inputs.version }} # zizmor: ignore[unpinned-tools]
         cache: ${{ inputs.cache }}
         token: ${{ inputs.token-setup-trivy }}
 


### PR DESCRIPTION
- `action.yaml`: suppress `unpinned-tools` false positive on `inputs.version` — zizmor doesn't see that the input has a pinned default value (v0.70.0), so the version is never actually unpinned
- `bump-trivy.yaml`: fix `github-app` error by scoping the App token to only `contents: write` and `pull-requests: write` instead of inheriting all installation permissions

Test run: https://github.com/nikpivkin/trivy-action/actions/runs/26590316939/job/78347085967