### PR TITLE
chore(docs): Update setup-trivy action reference to a valid tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Manual Trivy Setup
-      uses: aquasecurity/setup-trivy@v0.2.0
+      uses: aquasecurity/setup-trivy@v0.3.1
       with:
         cache: true
         version: v0.71.1


### PR DESCRIPTION
Update setup-trivy readme documentation to reference a valid tag for the action.

No associated issue due to being a trivial documentation issue.